### PR TITLE
docs(cicero-tutorial_001): Add "Install Cicero CLI" section

### DIFF
--- a/docs/cicero-tutorial_001.md
+++ b/docs/cicero-tutorial_001.md
@@ -13,16 +13,21 @@ In order to access the Cicero command line interface (CLI), install the `@accord
 
 `npm i -g @accordproject/cicero-cli`
 
-> The version of cicero-cli needs to match the cicero version, that is required by the template.
-> E.g. if the template requires version 0.5, cicero-cli 0.5 must be installed: `npm i -g @accordproject/cicero-cli@0.5`
+> If you're new to `npm` the [installation instructions](accordproject-tools.md) have some more detailed guidance.  
 
 ### Download the Template
 
-You can download a single clause or contract template from https://templates.accordproject.org as a zip file. Once downloaded unzip the archive so you can inspect the contents.
+You can download a single clause or contract template from the [Accord Project Template Library](https://templates.accordproject.org) as a zip file. Once downloaded unzip the archive so you can inspect the contents.
+
+> Note that the version of `cicero-cli` needs to match the Cicero version that is required by a template.
+> * You can check the version of your CLI with `cicero --version`. 
+> * You can choose a different version of a template with the *Versions* dropdown in the [Accord Project Template Library](https://templates.accordproject.org).
+> * Otherwise, install a specific version of the cli, for example for v0.5, use `npm i -g @accordproject/cicero-cli@0.5`.  
 
 If you have `git` installed you can `git clone` the template library to download all the templates, or you can use the "Download" button inside GitHub:
 
     git clone https://github.com/accordproject/cicero-template-library
+    
 
 ### Parse
 

--- a/docs/cicero-tutorial_001.md
+++ b/docs/cicero-tutorial_001.md
@@ -11,7 +11,10 @@ title: Quick Start Tutorial
 
 In order to access the Cicero command line interface (CLI), install the `@accordproject/cicero-cli` npm package:
 
-`npm i -g @accordproject/cicero-cli@0.4.4` (The template library currently requires cicero-cli version 0.4.4)
+`npm i -g @accordproject/cicero-cli`
+
+> The version of cicero-cli needs to match the cicero version, that is required by the template.
+> E.g. if the template requires version 0.5, cicero-cli 0.5 must be installed: `npm i -g @accordproject/cicero-cli@0.5`
 
 ### Download the Template
 
@@ -26,7 +29,7 @@ If you have `git` installed you can `git clone` the template library to download
 Using your terminal `cd` into the directory that contains the template you would like to test. In the example below we use the `helloworld` template.
 
 Use the `cicero parse` command to load a template from a directory on disk and then use
-it to parse input text, echoing the result of parsing. By default the file `sample.txt` if parsed. 
+it to parse input text, echoing the result of parsing. By default the file `sample.txt` if parsed.
 If the input text is valid the parsing result will be a JSON serialized instance of the Template Model:
 
 Sample template.tem:
@@ -40,7 +43,7 @@ Sample.txt:
 Parsing using the command line:
 
 ```
-    cd cicero-template-library 
+    cd cicero-template-library
     cicero parse
 ```
 
@@ -65,14 +68,14 @@ Rerun `cicero parse`. The output should now be:
 
 ```
     { Error: invalid syntax at line 1 col 1:
-    FUBAR  Name of the person to greet: "Dan". 
+    FUBAR  Name of the person to greet: "Dan".
     ^ Unexpected "F"
 ```
 
 ### Execute
 
 Use the `cicero execute` command to load a template from a directory on disk,
-instantiate a clause based on input text (defaults to `sample.txt`), and then invoke the clause using an 
+instantiate a clause based on input text (defaults to `sample.txt`), and then invoke the clause using an
 incoming JSON payload (defaults to `data.json`).
 
 data.json::
@@ -86,14 +89,14 @@ data.json::
 Commands:
 
 ```
-    cd cicero-template-library 
+    cd cicero-template-library
     cicero execute
 ```
 
-The results of execution (a JSON serialized object) are displayed. They include: 
+The results of execution (a JSON serialized object) are displayed. They include:
 
 * Details of the clause executed (name, version, SHA256 hash of clause data)
-* The incoming request object 
+* The incoming request object
 * The output response object
 * Output state
 * Emitted events
@@ -125,14 +128,14 @@ Note that in the response data from the template has been combined with data fro
 
 ## Creating a New Template
 
-Now that you have executed an existing template, let's create a new template. 
+Now that you have executed an existing template, let's create a new template.
 
 > If you would like to contribute your template back into the `cicero-template-library` please start by [forking](https://help.github.com/articles/fork-a-repo/) the `cicero-template-library` project on GitHub. This will make it easy for you to submit a pull request to get your new template added to the library.
 
 Install the template generator::
 
 ```
-    npm install -g yo 
+    npm install -g yo
     npm install -g yo @accordproject/generator-cicero-template
 ```
 
@@ -170,11 +173,11 @@ of the variable in the `template.tem` file.
 
 Note that the Hyperledger Composer Modeling Language primitive data types are:
 
-- String 
-- Long 
-- Integer 
-- DateTime 
-- Double 
+- String
+- Long
+- Integer
+- DateTime
+- Double
 - Boolean
 
 > Note that you can import common types (address, monetary amount, country code, etc.) from the Accord Project Model Repository: https://models.accordproject.org.

--- a/docs/cicero-tutorial_001.md
+++ b/docs/cicero-tutorial_001.md
@@ -7,6 +7,12 @@ title: Quick Start Tutorial
 
 ## Using an existing Template
 
+### Install Cicero CLI
+
+In order to access the Cicero command line interface (CLI), install the `@accordproject/cicero-cli` npm package:
+
+`npm i -g @accordproject/cicero-cli@0.4.4` (The template library currently requires cicero-cli version 0.4.4)
+
 ### Download the Template
 
 You can download a single clause or contract template from https://templates.accordproject.org as a zip file. Once downloaded unzip the archive so you can inspect the contents.


### PR DESCRIPTION
Proposing update to quickstart tutorial in order to clarify cicero-cli version and correct npm package, as suggested in https://github.com/accordproject/cicero/issues/50