### PR TITLE
fix(styles): fix wrong opacity on hovering

### DIFF
--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -3551,11 +3551,6 @@ position: relative;
 	flex: 2;
 }
 
-.nav-footer .sitemap .nav-home:hover,
-.nav-footer .sitemap .nav-home:focus {
-	opacity: 0.4;
-}
-
 @media only screen and (max-width: 735px) {
 	.nav-footer .sitemap {
 		display: flex;
@@ -3817,4 +3812,3 @@ padding: 0px;
     max-width: 460px;
     margin-top: 35px;
   }
-  


### PR DESCRIPTION
# Issue #93 
Fix for wrong hover on AP logo, to make it  consistent with  www.accordproject.org.

### Changes
Remove styles with the same selectors, which overrides the proper one

closes #93

