### PR TITLE
docs(README): Removes static contributors image

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ Join the Accord Project Technology Working Group [Slack channel][apslack] to get
 
 For code contributions, read our [CONTRIBUTING guide][contributing] and information for [DEVELOPERS][developers].
 
-<img src="./assets/contributors.png" alt="Profile pictures of Accord Project Contributors">
-
 ## License <a name="license"></a>
 
 Accord Project source code files are made available under the [Apache License, Version 2.0][apache].


### PR DESCRIPTION
# Issue #100 
Backs out change to add static image. Prepare for auto-generated image by the all-contributors bot