### PR TITLE
Fix spacing issues in sidebar nav menu

### DIFF
--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -1795,9 +1795,10 @@ fill: #19C6C6;
   line-height: 1.2em;
   margin-bottom: 8px;
   margin-top: 0;
+  margin-right: 3px;
   border-radius: 5px;
   background-color: #050c400d;
-  padding: 15px;
+  padding: 15px 8px;
 }
 
 .toc .toggleNav .navGroup .navGroupSubcategoryTitle {

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -1798,7 +1798,7 @@ fill: #19C6C6;
   margin-right: 3px;
   border-radius: 5px;
   background-color: #050c400d;
-  padding: 15px 8px;
+  padding: 15px 4px 15px 15px;
 }
 
 .toc .toggleNav .navGroup .navGroupSubcategoryTitle {


### PR DESCRIPTION
# Issue #116 
The sidebar nav menu for the docs has spacing issues

### Changes
- Reduced side padding for the list elements
- Added a margin to stop the list elements from touching the scrollbar

Will look like this:
![image](https://user-images.githubusercontent.com/43860191/66246018-18351580-e6d7-11e9-8eda-d6a8f5bc5936.png)

### Related Issues
- Issue #116
