### PR TITLE
fix(main page): fix url in slack button - I121

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -71,7 +71,7 @@ class Footer extends React.Component {
                 <a href="http://stackoverflow.com/questions/tagged/cicero" target="_blank" rel="noreferrer noopener"> Stack Overflow</a>
               </li>
               <li>
-                <a href="https://accord-project.slack.com/messages/C7U521CTG">Slack</a>
+                <a href="https://accord-project-slack-signup.herokuapp.com">Slack</a>
               </li>
               <li>
                 <a href="https://twitter.com/accordhq" target="_blank" rel="noreferrer noopener">

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -82,7 +82,7 @@ class HomeSplash extends React.Component {
             <Button href={docUrl('accordproject.html', this.props.language)}>Getting Started</Button>
             <Button href="#try">Try Online</Button>
             <Button href="https://github.com/accordproject">GitHub</Button>
-            <Button href="https://docs.google.com/forms/d/e/1FAIpQLScmPLO6vflTKFTRTJXiopCjGEvS5mMeH-ZlBnuStiQ3U4k19A/viewform">Slack</Button>
+            <Button href="https://accord-project-slack-signup.herokuapp.com/">Slack</Button>
           </PromoSection>
         </div>
       </SplashContainer>


### PR DESCRIPTION
# Issue #121 

### Changes
Change url for Slack button on main page from some google form, to https://accord-project-slack-signup.herokuapp.com/

Perhaps, that's not the end, and link in footer should also be changed 

closes #121 

P.S. if this change is not acceptable, or, not needed, feel free to close this PR and mark it with `invalid` label, just don't want to be a guy, who creates some spammy PRs to get a swag.