### PR TITLE
fix(docs): correct a typo

### DIFF
--- a/docs/accordproject.md
+++ b/docs/accordproject.md
@@ -55,7 +55,7 @@ The following screenshot shows the Ergo logic for the acceptance of delivery cla
 
 ![Ergo Logic](/img/ergo-vscode.png)
 
-It is important that a developer and a lawyer can together agree that clauses in a computable legal contract have the same semantics as the equivalent computer code. For that reason, Ergo is intended to be accessible to Lawyers who create the corresponding prose for those computable legal contracts. As a programming language, the Ergo syntax also adheres to programming conventions.
+It is important that a developer and a lawyer can together agree that clauses in a computable legal contract have the same semantics as the equivalent computer code. For that reason, Ergo is intended to be accessible to lawyers who create the corresponding prose for those computable legal contracts. As a programming language, the Ergo syntax also adheres to programming conventions.
 
 ## Ecosystem
 


### PR DESCRIPTION
# Issue #

### Changes
- Fixed a typo where "lawyers" was capitalized for no reason

### Flags