### PR TITLE
fix(website): change header logo to avoid search bar overlapping in smaller resolution

### DIFF
--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -782,6 +782,12 @@ blockquote {
     display: none !important;
   }
 }
+@media (max-width: 500px) {
+  img.logo {
+    content:url("../img/Accord-Project-logo-small.svg");
+  }
+}
+
 /* End of Navbar */
 
 /* Promo section */

--- a/website/static/img/Accord-Project-logo-small.svg
+++ b/website/static/img/Accord-Project-logo-small.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Laag_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 136.1 135.8" style="enable-background:new 0 0 136.1 135.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M88.1,135.8h48L92.3,0h-48l11.6,36.1H32.4L0,135.8h48l19.5-62.3h0.3L88.1,135.8z M85.8,9l38,117.8H94.7L56.7,9
+	H85.8z M65.1,64.5H47.3l-6.4-19.4h18L65.1,64.5z M41.5,126.8h-29l22.8-70.1l5.6,16.8h17.4L41.5,126.8z"/>
+</svg>


### PR DESCRIPTION
Signed-off-by: Sanket Shah <er.sanketshah@gmail.com>

# Issue #153 
Replacing the image (logo + text) to a smaller imager (logo) when the resolution is less than or equal to 480px

# Screenshot
<img width="465" alt="Screenshot 2019-10-10 at 1 09 51 AM" src="https://user-images.githubusercontent.com/6761317/66514466-ce936300-eafa-11e9-896a-e92e6abb3343.png">
