### PR TITLE
fixed formatting for markup-commonmark.md

### DIFF
--- a/docs/markup-commonmark.md
+++ b/docs/markup-commonmark.md
@@ -3,41 +3,50 @@ id: markup-commonmark
 title: Rich Text Markup
 ---
 
-The following guide is not normative; the official specification can be found on the [official CommonMark page](https://commonmark.org/).
+The following guide is not normative; the official specification can be found on the official [CommonMark page](https://commonmark.org/).
 
-## Formatting
-
-<!--Fonts-->
+# Formatting
 ## Fonts
-
 ### Italic
-
 To italicize text, simply add one asterisk `*` or underscore `_` both before and after the relevant text.
 
-For example, `_Donoghue v Stevenson_ is a landmark tort law case.` will be shown as:
-
+For example,
+```md
 _Donoghue v Stevenson_ is a landmark tort law case.
+```
+
+will be shown as:
+
+>_Donoghue v Stevenson_ is a landmark tort law case.
 
 ### Bold
 To bold text, simply add two asterisks `**` or two underscores `__` both before and after the relevant text.
 
-For example, `**Price** is defined in the Appendix.` will be shown as:
-
+For example,
+```md
 **Price** is defined in the Appendix.
+```
+
+will be shown as:
+
+> **Price** is defined in the Appendix.
 
 
 ### Bold and Italic
 To bold _and_ italicize text, add `***` both before and after the relevant text.
 
-For example, `*** WARNING***: This product contains chemicals that may cause cancer.` will be shown as:
-
+For example,
+```md
 ***WARNING***: This product contains chemicals that may cause cancer.
+```
+will be shown as:
+
+> ***WARNING***: This product contains chemicals that may cause cancer.
 
 
 ### Using \* or \_ in text
 To avoid creating bold or italic when using `*` or `_` in a sentence, place a backslash `\` in the front, like: `\*` or `\_`. In fact, any punctuation character that is used for a special purpose may be 'escaped' by placing a backslash in front of it.
 
-<!--Paragraphs-->
 ## Paragraphs
 To start a new paragraph, insert one or more blank lines. (In other words, all paragraphs in markdown need to have one or more blank lines between them.)
 
@@ -51,17 +60,18 @@ This is not a second paragraph.
 ```
 will be shown as:
 
-This is the first paragraph.
+>This is the first paragraph.
+>
+>This is the second paragraph.
+>This is not a second paragraph.
 
-This is the second paragraph.
-This is not a second paragraph.
 
-<!--Heading and Titles-->
 ## Headings
 
 ### Using hash `#`
 Headings from `h1` through `h6` are constructed with a `#` for each level:
-```
+
+```md
 # h1 US Constitution
 ## h2 Statutes enacted by Congress
 ### h3 Rules promulgated by federal agencies
@@ -69,20 +79,11 @@ Headings from `h1` through `h6` are constructed with a `#` for each level:
 ##### h5 Laws enacted by state legislature
 ###### h6 Local laws and ordinances
 ```
-
-Renders to:
-
-# h1 US Constitution
-## h2 Statutes enacted by Congress
-### h3 Rules promulgated by federal agencies
-#### h4 State constitution
-##### h5 Laws enacted by state legislature
-###### h6 Local laws and ordinances
 
 ### Using underlines
 Alternatively, headings 1 and 2 can be represented by using `=` and `-`:
-```
 
+```md
 Linux Foundation
 ================
 
@@ -90,54 +91,50 @@ Accord Project
 --------------
 ```
 
-Renders to:
 
-Linux Foundation
-================
+# Additional Features
 
-Accord Project
---------------
-
-
-<!--Perhaps less useful for generating contracts-->
-## Additional Features
-
-<!--Lists-->
 ## Lists
 
 ### Unordered Lists
-To create an unordered list, use asterisks `*`, plus `+`, or hyphens `-` in the beginning as list markers. For example:
-```
+To create an unordered list, use asterisks `*`, plus `+`, or hyphens `-` in the beginning as list markers.
+
+For example:
+```md
 * Cicero
 * Ergo
 * Concerto
 ```
 
 Renders to:
-* Cicero
-* Ergo
-* Concerto
+>* Cicero
+>* Ergo
+>* Concerto
 
 *Tip*: To use these characters without creating a list, simply include a backslash `\` in the beginning, like `\*`, `\+`, or `\-`.
 
 ### Ordered Lists
-To create an ordered list, use numbers followed by period `.`. For example:
-```
+To create an ordered list, use numbers followed by period `.`.
+
+For example:
+```md
 1. One
 2. Two
 3. Three
 ```
 
 will be shown as:
-1. One
-2. Two
-3. Three
+>1. One
+>2. Two
+>3. Three
 
 <!-- Sometimes lists change, and when they do it's a pain to re-order all of the numbers. Markdown solves this problem by allowing you to simply use 1. before each item in the list. Like this...-->
 
 ### Nested Lists
 
-To create a list within another, indent each item in the sublist by four spaces. For example:
+To create a list within another, indent each item in the sublist by four spaces.
+
+For example:
 ```md
 1. Matters related to the business
     - enter into an agreement...
@@ -148,28 +145,36 @@ To create a list within another, indent each item in the sublist by four spaces.
 ```
 
 will be rendered to:
-1. Matters related to the business
-    - enter into an agreement...
-    - enter into any abnormal contracts...
-2. Matters related to the assets
-    - sell or otherwise dispose...
-    - mortage, ...
+>1. Matters related to the business
+>    - enter into an agreement...
+>    - enter into any abnormal contracts...
+>2. Matters related to the assets
+>    - sell or otherwise dispose...
+>    - mortgage, ...
 
-<!--Horizontal Rule-->
+
 ## Horizontal Rule
+
 A horizontal rule may be used to create a "thematic break" between paragraph-level elements. In markdown, you can use of the following for this purpose:
 
 * `___`: three consecutive underscores
 * `---`: three consecutive dashes
 * `***`: three consecutive asterisks
 
+For example,
+```md
+___
+---
+***
+```
+
 This renders to:
 
-___
-
----
-
-***
+>___
+>
+>---
+>
+>***
 
 <!--References:
 Commonmark official page and tutorial: https://commonmark.org/help/


### PR DESCRIPTION
Signed-off-by: Katie <sa951009@gmail.com>

# Issue #175 
Fixed formatting issues, following feedback from @mttrbrts @irmerk @jeromesimeon at the technology-wg call

### Changes
- All code snippets now shown in code blocks 
- All 'rendered to' expressions shown in block quotes

### Flags
![Heading in blockquote](https://user-images.githubusercontent.com/45664641/66764473-c09a6500-eea1-11e9-95de-f31f14e1c515.png)
As can be seen from the screenshot, in the `headings` subsection: 
(LEFT) `##h2` and `###h3` are in block quotes
(RIGHT) but they still appear in the side bar as actual headings. 

The same problem appeared in the `using underlines` subsection.

As this may cause confusion and hinder user navigation, I deleted block quotes completely for those two sub-sections, so that this problem does not occur (and the sidebar is clean). Please let me know if there is a way to fix this. 

### Related Issues
- Issue #87 
- Pull Request #163 
