### PR TITLE
chore(gitignore): add thumbs.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ website/yarn.lock
 website/node_modules
 website/i18n/*
 !website/i18n/en.json
+
+thumbs.db


### PR DESCRIPTION
### Changes

`thumbs.db` is a windows directory cache file which sometimes gets pushed to repos, comes in commits, and can trouble other users. Now windows users can send PRs without having to worry about `thumbs.db`.

