### PR TITLE
fix(docs): correct link

### DIFF
--- a/docs/tutorial-latedelivery.md
+++ b/docs/tutorial-latedelivery.md
@@ -11,7 +11,7 @@ We start with a very simple _Late Penalty and Delivery_ Clause and gradually mak
 
 ### Load the Template
 
-To get started, head to the `minilatedeliveryandpenalty` template in the Accord Project Template Library at https://templates.accordproject.org/minilatedeliveryandpenalty@0.2.1.html and click the "Open In Template Studio" button.
+To get started, head to the `minilatedeliveryandpenalty` template in the Accord Project Template Library at https://templates.accordproject.org/minilatedeliveryandpenalty@0.4.0.html and click the "Open In Template Studio" button.
 
 ![Advanced-Late-1](assets/advanced/late1.png)
 


### PR DESCRIPTION
Signed-off-by: doomswatter <44559839+doomswatter@users.noreply.github.com>

# Issue #
Replaced link to old version of template with link to current version.

### Changes
- Replaced link to old version of template with link to current version.

### Flags
- 

### Related Issues
- Issue #
