### PR TITLE
fix(docs): correct link - I203

### DIFF
--- a/docs/tutorial-nodejs.md
+++ b/docs/tutorial-nodejs.md
@@ -7,7 +7,7 @@ title: Working with Node.js
 
 You can work with Accord Project templates directly in JavaScript using Node.js.
 
-Documentation for the API can be found in [Cicero API](https://github.com/accordproject/techdocs/blob/master/docs/cicero-api.md).
+Documentation for the API can be found in [Cicero API](https://docs.accordproject.org/docs/cicero-api.html).
 
 ## Working with Templates
 

--- a/docs/tutorial-nodejs.md
+++ b/docs/tutorial-nodejs.md
@@ -7,7 +7,7 @@ title: Working with Node.js
 
 You can work with Accord Project templates directly in JavaScript using Node.js.
 
-Documentation for the API can be found in [Cicero API](cicero-api).
+Documentation for the API can be found in [Cicero API](https://github.com/accordproject/techdocs/blob/master/docs/cicero-api.md).
 
 ## Working with Templates
 


### PR DESCRIPTION
Signed-off-by: doomswatter <44559839+doomswatter@users.noreply.github.com>

# Issue #203
Replaced broken link to Cicero API with correct one.

### Changes
- Replaced broken link to Cicero API with correct one.

### Flags
- 

### Related Issues
- Issue #203
