### PR TITLE
correcting the paragraph portion

### DIFF
--- a/docs/markup-commonmark.md
+++ b/docs/markup-commonmark.md
@@ -56,14 +56,14 @@ For example:
 This is the first paragraph.
 
 This is the second paragraph.
-This is not a second paragraph.
+This is not a third paragraph.
 ```
 will be shown as:
 
 >This is the first paragraph.
 >
 >This is the second paragraph.
->This is not a second paragraph.
+>This is not a third paragraph.
 
 
 ## Headings


### PR DESCRIPTION
as it was saying ">This is the second paragraph.
>This is not a second  paragraph." this expression was incorrect because in fact it was still the second paragraph, so instead i propose to change such portion to "this is not a third paragraph" to make the idea a bit more clear



# Issue #213 

### Changes
- <INSERT DESCRIPTION OF CHANGES>
  - <SUB NOTES OF DESCRIPTIONS>
- <SUMMARIZE ALL COMMITS IN PULL REQUEST>

### Flags
- <DESCRIBE ISSUES OR HOLDS FOR REVIEWERS>

Signed-off-by: Andres Arrieta <amaa.0310@gmail.com>
