### PR TITLE
Avoid 'simply' to replace or omit this word 

### DIFF
--- a/docs/accordproject-concepts.md
+++ b/docs/accordproject-concepts.md
@@ -54,7 +54,7 @@ obligations under this agreement, detailed in {{attachment}}, attached
 to this agreement.
 ```
 
-The text is written in plain English with variables between `{{` and `}}` and highlighted in blue. Using variables is useful so the same template can be used in different agreements by simply replacing them by different values.
+The text is written in plain English with variables between `{{` and `}}` and highlighted in blue. Using variables is useful so the same template can be used in different agreements by replacing them by different values.
 
 For instance, the following show the same acceptance of delivery clause where the `shipper` is `"Party A"`, the `receiver` is `"Party B"`, the `deliverable` is `"Widgets"`, etc.
 

--- a/website/versioned_docs/version-0.10.0/accordproject-specification.md
+++ b/website/versioned_docs/version-0.10.0/accordproject-specification.md
@@ -249,7 +249,7 @@ The logic for a Clause is implemented as a function, each of which takes a reque
 
 Given the template grammar and the template model above we can now edit (parameterise) the template to create a clause (an instance of the template).
 
-Next we need to ground the template to events that are happening in the real-world: packages are getting shipped, delivered, signed-for etc. We want those transactions to be routed to the template, so that it is aware of them and can take appropriate action. In this case the action is simply to calculate the penalty amount and signal whether the buyer may terminate the contract.
+Next we need to ground the template to events that are happening in the real-world: packages are getting shipped, delivered, signed-for etc. We want those transactions to be routed to the template, so that it is aware of them and can take appropriate action. In this case the action is just to calculate the penalty amount and signal whether the buyer may terminate the contract.
 
 ### Transactions
 
@@ -326,7 +326,7 @@ transaction LateDeliveryAndPenaltyResponse {
 }
 ```
 
-Here we are simply stating that execution this template will produce an instance of LateDeliveryAndPenaltyResponse.
+Here we are stating that execution this template will produce an instance of LateDeliveryAndPenaltyResponse.
 
 #### Event
 

--- a/website/versioned_docs/version-0.10.0/ergo-cli.md
+++ b/website/versioned_docs/version-0.10.0/ergo-cli.md
@@ -184,7 +184,7 @@ ergo$ call volumediscount(VolumeDiscountRequest{ netAnnualChargeVolume : 10.5 })
 Response. VolumeDiscountResponse{discountRate: 2.8} : VolumeDiscountResponse
 ```
 
-You can also invoke the contract without explicitely naming the clause by simply sending a request. The Ergo engine dispatches that request to the first clause which can handle it:
+You can also invoke the contract without explicitely naming the clause by sending a request. The Ergo engine dispatches that request to the first clause which can handle it:
 ```ergo
 ergo$ send VolumeDiscountRequest{ netAnnualChargeVolume : 0.1 }
 Response. VolumeDiscountResponse{discountRate: 3.0} : VolumeDiscountResponse

--- a/website/versioned_docs/version-0.10.0/ergo-lang.md
+++ b/website/versioned_docs/version-0.10.0/ergo-lang.md
@@ -25,7 +25,7 @@ The simplest kind of expressions in Ergo are literal values.
 
 Each line here is a separate expression. At the end of the line, the notation `// write something here` is a _comment_, which means it is a part of your Ergo program which is ignored by the Ergo compiler. It can be useful to document your code.
 
-Every Ergo expression can be _evaluated_, which means it should compute some value. In the case of a literal value, the result of evaluation is simply itself (e.g., the expression `1` evaluates to the integer `1`).
+Every Ergo expression can be _evaluated_, which means it should compute some value. In the case of a literal value, the result of evaluation is itself (e.g., the expression `1` evaluates to the integer `1`).
 
 > You can actually see the result of evaluating expressions by trying them out in the [Ergo REPL](https://ergorepl.netlify.com). You just have to prefix them with `return`: for instance, to evaluate the String literal `"John Smith"` type: `return "John Smith"` (followed by clicking the button 'Evaluate') in the REPL. This should answer: `Response. "John Smith" : String`.
 
@@ -628,7 +628,7 @@ Each Ergo file starts with a namespace declaration which provides a way to ident
 
 ### Libraries
 
-A library is simply an Ergo file in a namespace which defines useful constants or functions. For instance:
+A library is an Ergo file in a namespace which defines useful constants or functions. For instance:
 
 ```ergo
     namespace org.accordproject.ergo.money

--- a/website/versioned_docs/version-0.10.1/accordproject-specification.md
+++ b/website/versioned_docs/version-0.10.1/accordproject-specification.md
@@ -249,7 +249,7 @@ The logic for a Clause is implemented as a function, each of which takes a reque
 
 Given the template grammar and the template model above we can now edit (parameterise) the template to create a clause (an instance of the template).
 
-Next we need to ground the template to events that are happening in the real-world: packages are getting shipped, delivered, signed-for etc. We want those transactions to be routed to the template, so that it is aware of them and can take appropriate action. In this case the action is simply to calculate the penalty amount and signal whether the buyer may terminate the contract.
+Next we need to ground the template to events that are happening in the real-world: packages are getting shipped, delivered, signed-for etc. We want those transactions to be routed to the template, so that it is aware of them and can take appropriate action. In this case the action is to calculate the penalty amount and signal whether the buyer may terminate the contract.
 
 ### Transactions
 
@@ -326,7 +326,7 @@ transaction LateDeliveryAndPenaltyResponse {
 }
 ```
 
-Here we are simply stating that execution this template will produce an instance of LateDeliveryAndPenaltyResponse.
+Here we are stating that execution this template will produce an instance of LateDeliveryAndPenaltyResponse.
 
 #### Event
 

--- a/website/versioned_docs/version-0.10.1/ergo-lang.md
+++ b/website/versioned_docs/version-0.10.1/ergo-lang.md
@@ -25,7 +25,7 @@ The simplest kind of expressions in Ergo are literal values.
 
 Each line here is a separate expression. At the end of the line, the notation `// write something here` is a _comment_, which means it is a part of your Ergo program which is ignored by the Ergo compiler. It can be useful to document your code.
 
-Every Ergo expression can be _evaluated_, which means it should compute some value. In the case of a literal value, the result of evaluation is simply itself (e.g., the expression `1` evaluates to the integer `1`).
+Every Ergo expression can be _evaluated_, which means it should compute some value. In the case of a literal value, the result of evaluation is itself (e.g., the expression `1` evaluates to the integer `1`).
 
 > You can actually see the result of evaluating expressions by trying them out in the [Ergo REPL](https://ergorepl.netlify.com). You just have to prefix them with `return`: for instance, to evaluate the String literal `"John Smith"` type: `return "John Smith"` (followed by clicking the button 'Evaluate') in the REPL. This should answer: `Response. "John Smith" : String`.
 
@@ -628,7 +628,7 @@ Each Ergo file starts with a namespace declaration which provides a way to ident
 
 ### Libraries
 
-A library is simply an Ergo file in a namespace which defines useful constants or functions. For instance:
+A library is an Ergo file in a namespace which defines useful constants or functions. For instance:
 
 ```ergo
     namespace org.accordproject.ergo.money

--- a/website/versioned_docs/version-0.9.9/accordproject-specification.md
+++ b/website/versioned_docs/version-0.9.9/accordproject-specification.md
@@ -249,7 +249,7 @@ The logic for a Clause is implemented as a function, each of which takes a reque
 
 Given the template grammar and the template model above we can now edit (parameterise) the template to create a clause (an instance of the template).
 
-Next we need to ground the template to events that are happening in the real-world: packages are getting shipped, delivered, signed-for etc. We want those transactions to be routed to the template, so that it is aware of them and can take appropriate action. In this case the action is simply to calculate the penalty amount and signal whether the buyer may terminate the contract.
+Next we need to ground the template to events that are happening in the real-world: packages are getting shipped, delivered, signed-for etc. We want those transactions to be routed to the template, so that it is aware of them and can take appropriate action. In this case the action is  to calculate the penalty amount and signal whether the buyer may terminate the contract.
 
 ### Transactions
 
@@ -326,7 +326,7 @@ transaction LateDeliveryAndPenaltyResponse {
 }
 ```
 
-Here we are simply stating that execution this template will produce an instance of LateDeliveryAndPenaltyResponse.
+Here we are  stating that execution this template will produce an instance of LateDeliveryAndPenaltyResponse.
 
 #### Event
 


### PR DESCRIPTION
Hi there, 

# Issue #184 

### Changes
- I change omit and replace 'simply' from the documentation