### PR TITLE
style(css): increased spacing for navbar

### DIFF
--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -1486,7 +1486,7 @@ input::placeholder {
     line-height: 1.2em;
     margin: 0;
     padding: 0;
-    padding: 6px 10px;
+    padding: 6px 20px;
   }
 
   .navigationSlider .slidingNav ul li a:hover,


### PR DESCRIPTION
The upper left navbar elements in the main page for docs are a bit too close to each other, so I spaced them out a bit.

Original:
![image](https://user-images.githubusercontent.com/43860191/67608202-d2ef8b00-f74c-11e9-8d04-52f9f941c871.png)
New:
![image](https://user-images.githubusercontent.com/43860191/67608210-e3a00100-f74c-11e9-9ed7-d4090eb7df6e.png)


### Changes
- changed horizontal padding for 3 elements by 10px
