### PR TITLE
fix(api): Missing API docs for cicero and concerto

### DIFF
--- a/docs/cicero-api.md
+++ b/docs/cicero-api.md
@@ -50,6 +50,10 @@ A TemplateInstance must be constructed with a template and then prior to executi
 Set the data for the TemplateInstance by either calling the setData method or by
 calling the parse method and passing in natural language text that conforms to the template grammar.</p>
 </dd>
+<dt><a href="#CompositeArchiveLoader">CompositeArchiveLoader</a></dt>
+<dd><p>Manages a set of archive loaders, delegating to the first archive
+loader that accepts a URL.</p>
+</dd>
 </dl>
 
 ## Functions
@@ -1031,6 +1035,68 @@ to a Moment.
 | --- | --- | --- |
 | obj | <code>\*</code> | the input object |
 | utcOffset | <code>number</code> | the default utcOffset |
+
+<a name="CompositeArchiveLoader"></a>
+
+## CompositeArchiveLoader
+Manages a set of archive loaders, delegating to the first archive
+loader that accepts a URL.
+
+**Kind**: global class  
+
+* [CompositeArchiveLoader](#CompositeArchiveLoader)
+    * [new CompositeArchiveLoader()](#new_CompositeArchiveLoader_new)
+    * [.addArchiveLoader(archiveLoader)](#CompositeArchiveLoader+addArchiveLoader)
+    * [.clearArchiveLoaders()](#CompositeArchiveLoader+clearArchiveLoaders)
+    * *[.accepts(url)](#CompositeArchiveLoader+accepts) ⇒ <code>boolean</code>*
+    * [.load(url, options)](#CompositeArchiveLoader+load) ⇒ <code>Promise</code>
+
+<a name="new_CompositeArchiveLoader_new"></a>
+
+### new CompositeArchiveLoader()
+Create the CompositeArchiveLoader. Used to delegate to a set of ArchiveLoaders.
+
+<a name="CompositeArchiveLoader+addArchiveLoader"></a>
+
+### compositeArchiveLoader.addArchiveLoader(archiveLoader)
+Adds a ArchiveLoader implemenetation to the ArchiveLoader
+
+**Kind**: instance method of [<code>CompositeArchiveLoader</code>](#CompositeArchiveLoader)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| archiveLoader | <code>ArchiveLoader</code> | The archive to add to the CompositeArchiveLoader |
+
+<a name="CompositeArchiveLoader+clearArchiveLoaders"></a>
+
+### compositeArchiveLoader.clearArchiveLoaders()
+Remove all registered ArchiveLoaders
+
+**Kind**: instance method of [<code>CompositeArchiveLoader</code>](#CompositeArchiveLoader)  
+<a name="CompositeArchiveLoader+accepts"></a>
+
+### *compositeArchiveLoader.accepts(url) ⇒ <code>boolean</code>*
+Returns true if this ArchiveLoader can process the URL
+
+**Kind**: instance abstract method of [<code>CompositeArchiveLoader</code>](#CompositeArchiveLoader)  
+**Returns**: <code>boolean</code> - true if this ArchiveLoader accepts the URL  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | the URL |
+
+<a name="CompositeArchiveLoader+load"></a>
+
+### compositeArchiveLoader.load(url, options) ⇒ <code>Promise</code>
+Load a Archive from a URL and return it
+
+**Kind**: instance method of [<code>CompositeArchiveLoader</code>](#CompositeArchiveLoader)  
+**Returns**: <code>Promise</code> - a promise to the Archive  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | the url to get |
+| options | <code>object</code> | additional options |
 
 <a name="locationOfError"></a>
 

--- a/docs/concerto-api.md
+++ b/docs/concerto-api.md
@@ -12,9 +12,65 @@ specific models.
 
 * [concerto-core](#module_concerto-core)
     * _static_
+        * [.ModelLoader](#module_concerto-core.ModelLoader)
+            * [.loadModelManager(ctoSystemFile, ctoFiles)](#module_concerto-core.ModelLoader.loadModelManager) ⇒ <code>object</code>
         * [.DecoratorFactory](#module_concerto-core.DecoratorFactory)
             * *[.newDecorator(parent, ast)](#module_concerto-core.DecoratorFactory+newDecorator) ⇒ <code>Decorator</code>*
     * _inner_
+        * [~BaseException](#module_concerto-core.BaseException) ⇐ <code>Error</code>
+            * [new BaseException(message, component)](#new_module_concerto-core.BaseException_new)
+        * [~BaseFileException](#module_concerto-core.BaseFileException) ⇐ <code>BaseException</code>
+            * [new BaseFileException(message, fileLocation, fullMessage, fileName, component)](#new_module_concerto-core.BaseFileException_new)
+            * [.getFileLocation()](#module_concerto-core.BaseFileException+getFileLocation) ⇒ <code>string</code>
+            * [.getShortMessage()](#module_concerto-core.BaseFileException+getShortMessage) ⇒ <code>string</code>
+            * [.getFileName()](#module_concerto-core.BaseFileException+getFileName) ⇒ <code>string</code>
+        * [~Factory](#module_concerto-core.Factory)
+            * [new Factory(modelManager)](#new_module_concerto-core.Factory_new)
+            * _instance_
+                * [.newResource(ns, type, id, [options])](#module_concerto-core.Factory+newResource) ⇒ <code>Resource</code>
+                * [.newConcept(ns, type, [options])](#module_concerto-core.Factory+newConcept) ⇒ <code>Resource</code>
+                * [.newRelationship(ns, type, id)](#module_concerto-core.Factory+newRelationship) ⇒ <code>Relationship</code>
+                * [.newTransaction(ns, type, [id], [options])](#module_concerto-core.Factory+newTransaction) ⇒ <code>Resource</code>
+                * [.newEvent(ns, type, [id], [options])](#module_concerto-core.Factory+newEvent) ⇒ <code>Resource</code>
+            * _static_
+                * [.Symbol.hasInstance(object)](#module_concerto-core.Factory.Symbol.hasInstance) ⇒ <code>boolean</code>
+        * [~ModelManager](#module_concerto-core.ModelManager)
+            * [new ModelManager()](#new_module_concerto-core.ModelManager_new)
+            * _instance_
+                * [.validateModelFile(modelFile, fileName)](#module_concerto-core.ModelManager+validateModelFile)
+                * [.addModelFile(modelFile, fileName, [disableValidation], [systemModelTable])](#module_concerto-core.ModelManager+addModelFile) ⇒ <code>Object</code>
+                * [.updateModelFile(modelFile, fileName, [disableValidation])](#module_concerto-core.ModelManager+updateModelFile) ⇒ <code>Object</code>
+                * [.deleteModelFile(namespace)](#module_concerto-core.ModelManager+deleteModelFile)
+                * [.addModelFiles(modelFiles, [fileNames], [disableValidation], [systemModelTable])](#module_concerto-core.ModelManager+addModelFiles) ⇒ <code>Array.&lt;Object&gt;</code>
+                * [.validateModelFiles()](#module_concerto-core.ModelManager+validateModelFiles)
+                * [.updateExternalModels([options], [modelFileDownloader])](#module_concerto-core.ModelManager+updateExternalModels) ⇒ <code>Promise</code>
+                * [.writeModelsToFileSystem(path, [options])](#module_concerto-core.ModelManager+writeModelsToFileSystem)
+                * [.getModels([options])](#module_concerto-core.ModelManager+getModels) ⇒ <code>Array.&lt;{name:string, content:string}&gt;</code>
+                * [.clearModelFiles()](#module_concerto-core.ModelManager+clearModelFiles)
+                * [.getNamespaces()](#module_concerto-core.ModelManager+getNamespaces) ⇒ <code>Array.&lt;string&gt;</code>
+                * [.getSystemTypes()](#module_concerto-core.ModelManager+getSystemTypes) ⇒ <code>Array.&lt;ClassDeclaration&gt;</code>
+                * [.getAssetDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getAssetDeclarations) ⇒ <code>Array.&lt;AssetDeclaration&gt;</code>
+                * [.getTransactionDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getTransactionDeclarations) ⇒ <code>Array.&lt;TransactionDeclaration&gt;</code>
+                * [.getEventDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getEventDeclarations) ⇒ <code>Array.&lt;EventDeclaration&gt;</code>
+                * [.getParticipantDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getParticipantDeclarations) ⇒ <code>Array.&lt;ParticipantDeclaration&gt;</code>
+                * [.getEnumDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getEnumDeclarations) ⇒ <code>Array.&lt;EnumDeclaration&gt;</code>
+                * [.getConceptDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getConceptDeclarations) ⇒ <code>Array.&lt;ConceptDeclaration&gt;</code>
+                * [.getFactory()](#module_concerto-core.ModelManager+getFactory) ⇒ <code>Factory</code>
+                * [.getSerializer()](#module_concerto-core.ModelManager+getSerializer) ⇒ <code>Serializer</code>
+                * [.getDecoratorFactories()](#module_concerto-core.ModelManager+getDecoratorFactories) ⇒ <code>Array.&lt;DecoratorFactory&gt;</code>
+                * [.addDecoratorFactory(factory)](#module_concerto-core.ModelManager+addDecoratorFactory)
+            * _static_
+                * [.Symbol.hasInstance(object)](#module_concerto-core.ModelManager.Symbol.hasInstance) ⇒ <code>boolean</code>
+        * [~SecurityException](#module_concerto-core.SecurityException) ⇐ <code>BaseException</code>
+            * [new SecurityException(message)](#new_module_concerto-core.SecurityException_new)
+        * [~Serializer](#module_concerto-core.Serializer)
+            * [new Serializer(factory, modelManager)](#new_module_concerto-core.Serializer_new)
+            * _instance_
+                * [.setDefaultOptions(newDefaultOptions)](#module_concerto-core.Serializer+setDefaultOptions)
+                * [.toJSON(resource, [options])](#module_concerto-core.Serializer+toJSON) ⇒ <code>Object</code>
+                * [.fromJSON(jsonObject, options)](#module_concerto-core.Serializer+fromJSON) ⇒ <code>Resource</code>
+            * _static_
+                * [.Symbol.hasInstance(object)](#module_concerto-core.Serializer.Symbol.hasInstance) ⇒ <code>boolean</code>
         * [~AssetDeclaration](#module_concerto-core.AssetDeclaration) ⇐ <code>ClassDeclaration</code>
             * [new AssetDeclaration(modelFile, ast)](#new_module_concerto-core.AssetDeclaration_new)
             * _instance_
@@ -144,6 +200,27 @@ specific models.
             * _static_
                 * [.Symbol.hasInstance(object)](#module_concerto-core.TransactionDeclaration.Symbol.hasInstance) ⇒ <code>boolean</code>
 
+<a name="module_concerto-core.ModelLoader"></a>
+
+### concerto-core.ModelLoader
+Create a ModelManager from model files, with an optional system model.
+
+If a ctoFile is not provided, the Accord Project system model is used.
+
+**Kind**: static class of [<code>concerto-core</code>](#module_concerto-core)  
+<a name="module_concerto-core.ModelLoader.loadModelManager"></a>
+
+#### ModelLoader.loadModelManager(ctoSystemFile, ctoFiles) ⇒ <code>object</code>
+Load system and models in a new model manager
+
+**Kind**: static method of [<code>ModelLoader</code>](#module_concerto-core.ModelLoader)  
+**Returns**: <code>object</code> - the model manager  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ctoSystemFile | <code>string</code> | the system model file |
+| ctoFiles | <code>Array.&lt;string&gt;</code> | the CTO files (can be local file paths or URLs) |
+
 <a name="module_concerto-core.DecoratorFactory"></a>
 
 ### concerto-core.DecoratorFactory
@@ -164,6 +241,668 @@ decorator, or return null if this decorator is not handled by this processor.
 | --- | --- | --- |
 | parent | <code>ClassDeclaration</code> \| <code>Property</code> | the owner of this property |
 | ast | <code>Object</code> | The AST created by the parser |
+
+<a name="module_concerto-core.BaseException"></a>
+
+### concerto-core~BaseException ⇐ <code>Error</code>
+A base class for all Concerto exceptions
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+**Extends**: <code>Error</code>  
+<a name="new_module_concerto-core.BaseException_new"></a>
+
+#### new BaseException(message, component)
+Create the BaseException.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>string</code> | The exception message. |
+| component | <code>string</code> | The optional component which throws this error. |
+
+<a name="module_concerto-core.BaseFileException"></a>
+
+### concerto-core~BaseFileException ⇐ <code>BaseException</code>
+Exception throws when a Concerto file is semantically invalid
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+**Extends**: <code>BaseException</code>  
+**See**: [BaseException](BaseException)  
+
+* [~BaseFileException](#module_concerto-core.BaseFileException) ⇐ <code>BaseException</code>
+    * [new BaseFileException(message, fileLocation, fullMessage, fileName, component)](#new_module_concerto-core.BaseFileException_new)
+    * [.getFileLocation()](#module_concerto-core.BaseFileException+getFileLocation) ⇒ <code>string</code>
+    * [.getShortMessage()](#module_concerto-core.BaseFileException+getShortMessage) ⇒ <code>string</code>
+    * [.getFileName()](#module_concerto-core.BaseFileException+getFileName) ⇒ <code>string</code>
+
+<a name="new_module_concerto-core.BaseFileException_new"></a>
+
+#### new BaseFileException(message, fileLocation, fullMessage, fileName, component)
+Create an BaseFileException
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>string</code> | the message for the exception |
+| fileLocation | <code>string</code> | the optional file location associated with the exception |
+| fullMessage | <code>string</code> | the optional full message text |
+| fileName | <code>string</code> | the optional file name |
+| component | <code>string</code> | the optional component which throws this error |
+
+<a name="module_concerto-core.BaseFileException+getFileLocation"></a>
+
+#### baseFileException.getFileLocation() ⇒ <code>string</code>
+Returns the file location associated with the exception or null
+
+**Kind**: instance method of [<code>BaseFileException</code>](#module_concerto-core.BaseFileException)  
+**Returns**: <code>string</code> - the optional location associated with the exception  
+<a name="module_concerto-core.BaseFileException+getShortMessage"></a>
+
+#### baseFileException.getShortMessage() ⇒ <code>string</code>
+Returns the error message without the location of the error
+
+**Kind**: instance method of [<code>BaseFileException</code>](#module_concerto-core.BaseFileException)  
+**Returns**: <code>string</code> - the error message  
+<a name="module_concerto-core.BaseFileException+getFileName"></a>
+
+#### baseFileException.getFileName() ⇒ <code>string</code>
+Returns the fileName for the error
+
+**Kind**: instance method of [<code>BaseFileException</code>](#module_concerto-core.BaseFileException)  
+**Returns**: <code>string</code> - the file name or null  
+<a name="module_concerto-core.Factory"></a>
+
+### concerto-core~Factory
+Use the Factory to create instances of Resource: transactions, participants
+and assets.
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+
+* [~Factory](#module_concerto-core.Factory)
+    * [new Factory(modelManager)](#new_module_concerto-core.Factory_new)
+    * _instance_
+        * [.newResource(ns, type, id, [options])](#module_concerto-core.Factory+newResource) ⇒ <code>Resource</code>
+        * [.newConcept(ns, type, [options])](#module_concerto-core.Factory+newConcept) ⇒ <code>Resource</code>
+        * [.newRelationship(ns, type, id)](#module_concerto-core.Factory+newRelationship) ⇒ <code>Relationship</code>
+        * [.newTransaction(ns, type, [id], [options])](#module_concerto-core.Factory+newTransaction) ⇒ <code>Resource</code>
+        * [.newEvent(ns, type, [id], [options])](#module_concerto-core.Factory+newEvent) ⇒ <code>Resource</code>
+    * _static_
+        * [.Symbol.hasInstance(object)](#module_concerto-core.Factory.Symbol.hasInstance) ⇒ <code>boolean</code>
+
+<a name="new_module_concerto-core.Factory_new"></a>
+
+#### new Factory(modelManager)
+Create the factory.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelManager | <code>ModelManager</code> | The ModelManager to use for this registry |
+
+<a name="module_concerto-core.Factory+newResource"></a>
+
+#### factory.newResource(ns, type, id, [options]) ⇒ <code>Resource</code>
+Create a new Resource with a given namespace, type name and id
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Resource</code> - the new instance  
+**Throws**:
+
+- <code>TypeNotFoundException</code> if the type is not registered with the ModelManager
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the Resource |
+| type | <code>String</code> | the type of the Resource |
+| id | <code>String</code> | the identifier |
+| [options] | <code>Object</code> | an optional set of options |
+| [options.disableValidation] | <code>boolean</code> | pass true if you want the factory to return a [Resource](Resource) instead of a [ValidatedResource](ValidatedResource). Defaults to false. |
+| [options.generate] | <code>String</code> | Pass one of: <dl> <dt>sample</dt><dd>return a resource instance with generated sample data.</dd> <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl> |
+| [options.includeOptionalFields] | <code>boolean</code> | if <code>options.generate</code> is specified, whether optional fields should be generated. |
+| [options.allowEmptyId] | <code>boolean</code> | if <code>options.allowEmptyId</code> is specified as true, a zero length string for id is allowed (allows it to be filled in later). |
+
+<a name="module_concerto-core.Factory+newConcept"></a>
+
+#### factory.newConcept(ns, type, [options]) ⇒ <code>Resource</code>
+Create a new Concept with a given namespace and type name
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Resource</code> - the new instance  
+**Throws**:
+
+- <code>TypeNotFoundException</code> if the type is not registered with the ModelManager
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the Concept |
+| type | <code>String</code> | the type of the Concept |
+| [options] | <code>Object</code> | an optional set of options |
+| [options.disableValidation] | <code>boolean</code> | pass true if you want the factory to return a [Concept](Concept) instead of a [ValidatedConcept](ValidatedConcept). Defaults to false. |
+| [options.generate] | <code>String</code> | Pass one of: <dl> <dt>sample</dt><dd>return a resource instance with generated sample data.</dd> <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl> |
+| [options.includeOptionalFields] | <code>boolean</code> | if <code>options.generate</code> is specified, whether optional fields should be generated. |
+
+<a name="module_concerto-core.Factory+newRelationship"></a>
+
+#### factory.newRelationship(ns, type, id) ⇒ <code>Relationship</code>
+Create a new Relationship with a given namespace, type and identifier.
+A relationship is a typed pointer to an instance. I.e the relationship
+with `namespace = 'org.example'`, `type = 'Vehicle'` and `id = 'ABC' creates`
+a pointer that points at an instance of org.example.Vehicle with the id
+ABC.
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Relationship</code> - - the new relationship instance  
+**Throws**:
+
+- <code>TypeNotFoundException</code> if the type is not registered with the ModelManager
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the Resource |
+| type | <code>String</code> | the type of the Resource |
+| id | <code>String</code> | the identifier |
+
+<a name="module_concerto-core.Factory+newTransaction"></a>
+
+#### factory.newTransaction(ns, type, [id], [options]) ⇒ <code>Resource</code>
+Create a new transaction object. The identifier of the transaction is
+set to a UUID.
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Resource</code> - A resource for the new transaction.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the transaction. |
+| type | <code>String</code> | the type of the transaction. |
+| [id] | <code>String</code> | an optional identifier for the transaction; if you do not specify one then an identifier will be automatically generated. |
+| [options] | <code>Object</code> | an optional set of options |
+| [options.generate] | <code>String</code> | Pass one of: <dl> <dt>sample</dt><dd>return a resource instance with generated sample data.</dd> <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl> |
+| [options.includeOptionalFields] | <code>boolean</code> | if <code>options.generate</code> is specified, whether optional fields should be generated. |
+| [options.allowEmptyId] | <code>boolean</code> | if <code>options.allowEmptyId</code> is specified as true, a zero length string for id is allowed (allows it to be filled in later). |
+
+<a name="module_concerto-core.Factory+newEvent"></a>
+
+#### factory.newEvent(ns, type, [id], [options]) ⇒ <code>Resource</code>
+Create a new event object. The identifier of the event is
+set to a UUID.
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Resource</code> - A resource for the new event.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the event. |
+| type | <code>String</code> | the type of the event. |
+| [id] | <code>String</code> | an optional identifier for the event; if you do not specify one then an identifier will be automatically generated. |
+| [options] | <code>Object</code> | an optional set of options |
+| [options.generate] | <code>String</code> | Pass one of: <dl> <dt>sample</dt><dd>return a resource instance with generated sample data.</dd> <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl> |
+| [options.includeOptionalFields] | <code>boolean</code> | if <code>options.generate</code> is specified, whether optional fields should be generated. |
+| [options.allowEmptyId] | <code>boolean</code> | if <code>options.allowEmptyId</code> is specified as true, a zero length string for id is allowed (allows it to be filled in later). |
+
+<a name="module_concerto-core.Factory.Symbol.hasInstance"></a>
+
+#### Factory.Symbol.hasInstance(object) ⇒ <code>boolean</code>
+Alternative instanceof that is reliable across different module instances
+
+**Kind**: static method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>boolean</code> - - True, if the object is an instance of a Factory  
+**See**: https://github.com/hyperledger/composer-concerto/issues/47  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| object | <code>object</code> | The object to test against |
+
+<a name="module_concerto-core.ModelManager"></a>
+
+### concerto-core~ModelManager
+Manages the Concerto model files.
+
+The structure of [Resource](Resource)s (Assets, Transactions, Participants) is modelled
+in a set of Concerto files. The contents of these files are managed
+by the [ModelManager](ModelManager). Each Concerto file has a single namespace and contains
+a set of asset, transaction and participant type definitions.
+
+Concerto applications load their Concerto files and then call the [addModelFile](ModelManager#addModelFile)
+method to register the Concerto file(s) with the ModelManager. The ModelManager
+parses the text of the Concerto file and will make all defined types available
+to other Concerto services, such as the [Serializer](Serializer) (to convert instances to/from JSON)
+and [Factory](Factory) (to create instances).
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+
+* [~ModelManager](#module_concerto-core.ModelManager)
+    * [new ModelManager()](#new_module_concerto-core.ModelManager_new)
+    * _instance_
+        * [.validateModelFile(modelFile, fileName)](#module_concerto-core.ModelManager+validateModelFile)
+        * [.addModelFile(modelFile, fileName, [disableValidation], [systemModelTable])](#module_concerto-core.ModelManager+addModelFile) ⇒ <code>Object</code>
+        * [.updateModelFile(modelFile, fileName, [disableValidation])](#module_concerto-core.ModelManager+updateModelFile) ⇒ <code>Object</code>
+        * [.deleteModelFile(namespace)](#module_concerto-core.ModelManager+deleteModelFile)
+        * [.addModelFiles(modelFiles, [fileNames], [disableValidation], [systemModelTable])](#module_concerto-core.ModelManager+addModelFiles) ⇒ <code>Array.&lt;Object&gt;</code>
+        * [.validateModelFiles()](#module_concerto-core.ModelManager+validateModelFiles)
+        * [.updateExternalModels([options], [modelFileDownloader])](#module_concerto-core.ModelManager+updateExternalModels) ⇒ <code>Promise</code>
+        * [.writeModelsToFileSystem(path, [options])](#module_concerto-core.ModelManager+writeModelsToFileSystem)
+        * [.getModels([options])](#module_concerto-core.ModelManager+getModels) ⇒ <code>Array.&lt;{name:string, content:string}&gt;</code>
+        * [.clearModelFiles()](#module_concerto-core.ModelManager+clearModelFiles)
+        * [.getNamespaces()](#module_concerto-core.ModelManager+getNamespaces) ⇒ <code>Array.&lt;string&gt;</code>
+        * [.getSystemTypes()](#module_concerto-core.ModelManager+getSystemTypes) ⇒ <code>Array.&lt;ClassDeclaration&gt;</code>
+        * [.getAssetDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getAssetDeclarations) ⇒ <code>Array.&lt;AssetDeclaration&gt;</code>
+        * [.getTransactionDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getTransactionDeclarations) ⇒ <code>Array.&lt;TransactionDeclaration&gt;</code>
+        * [.getEventDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getEventDeclarations) ⇒ <code>Array.&lt;EventDeclaration&gt;</code>
+        * [.getParticipantDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getParticipantDeclarations) ⇒ <code>Array.&lt;ParticipantDeclaration&gt;</code>
+        * [.getEnumDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getEnumDeclarations) ⇒ <code>Array.&lt;EnumDeclaration&gt;</code>
+        * [.getConceptDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getConceptDeclarations) ⇒ <code>Array.&lt;ConceptDeclaration&gt;</code>
+        * [.getFactory()](#module_concerto-core.ModelManager+getFactory) ⇒ <code>Factory</code>
+        * [.getSerializer()](#module_concerto-core.ModelManager+getSerializer) ⇒ <code>Serializer</code>
+        * [.getDecoratorFactories()](#module_concerto-core.ModelManager+getDecoratorFactories) ⇒ <code>Array.&lt;DecoratorFactory&gt;</code>
+        * [.addDecoratorFactory(factory)](#module_concerto-core.ModelManager+addDecoratorFactory)
+    * _static_
+        * [.Symbol.hasInstance(object)](#module_concerto-core.ModelManager.Symbol.hasInstance) ⇒ <code>boolean</code>
+
+<a name="new_module_concerto-core.ModelManager_new"></a>
+
+#### new ModelManager()
+Create the ModelManager.
+
+<a name="module_concerto-core.ModelManager+validateModelFile"></a>
+
+#### modelManager.validateModelFile(modelFile, fileName)
+Validates a Concerto file (as a string) to the ModelManager.
+Concerto files have a single namespace.
+
+Note that if there are dependencies between multiple files the files
+must be added in dependency order, or the addModelFiles method can be
+used to add a set of files irrespective of dependencies.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Throws**:
+
+- <code>IllegalModelException</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelFile | <code>string</code> | The Concerto file as a string |
+| fileName | <code>string</code> | an optional file name to associate with the model file |
+
+<a name="module_concerto-core.ModelManager+addModelFile"></a>
+
+#### modelManager.addModelFile(modelFile, fileName, [disableValidation], [systemModelTable]) ⇒ <code>Object</code>
+Adds a Concerto file (as a string) to the ModelManager.
+Concerto files have a single namespace. If a Concerto file with the
+same namespace has already been added to the ModelManager then it
+will be replaced.
+Note that if there are dependencies between multiple files the files
+must be added in dependency order, or the addModelFiles method can be
+used to add a set of files irrespective of dependencies.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Object</code> - The newly added model file (internal).  
+**Throws**:
+
+- <code>IllegalModelException</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelFile | <code>string</code> | The Concerto file as a string |
+| fileName | <code>string</code> | an optional file name to associate with the model file |
+| [disableValidation] | <code>boolean</code> | If true then the model files are not validated |
+| [systemModelTable] | <code>boolean</code> | A table that maps classes in the new models to system types |
+
+<a name="module_concerto-core.ModelManager+updateModelFile"></a>
+
+#### modelManager.updateModelFile(modelFile, fileName, [disableValidation]) ⇒ <code>Object</code>
+Updates a Concerto file (as a string) on the ModelManager.
+Concerto files have a single namespace. If a Concerto file with the
+same namespace has already been added to the ModelManager then it
+will be replaced.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Object</code> - The newly added model file (internal).  
+**Throws**:
+
+- <code>IllegalModelException</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelFile | <code>string</code> | The Concerto file as a string |
+| fileName | <code>string</code> | an optional file name to associate with the model file |
+| [disableValidation] | <code>boolean</code> | If true then the model files are not validated |
+
+<a name="module_concerto-core.ModelManager+deleteModelFile"></a>
+
+#### modelManager.deleteModelFile(namespace)
+Remove the Concerto file for a given namespace
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| namespace | <code>string</code> | The namespace of the model file to delete. |
+
+<a name="module_concerto-core.ModelManager+addModelFiles"></a>
+
+#### modelManager.addModelFiles(modelFiles, [fileNames], [disableValidation], [systemModelTable]) ⇒ <code>Array.&lt;Object&gt;</code>
+Add a set of Concerto files to the model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;Object&gt;</code> - The newly added model files (internal).  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelFiles | <code>Array.&lt;string&gt;</code> | An array of Concerto files as strings. |
+| [fileNames] | <code>Array.&lt;string&gt;</code> | An optional array of file names to associate with the model files |
+| [disableValidation] | <code>boolean</code> | If true then the model files are not validated |
+| [systemModelTable] | <code>boolean</code> | A table that maps classes in the new models to system types |
+
+<a name="module_concerto-core.ModelManager+validateModelFiles"></a>
+
+#### modelManager.validateModelFiles()
+Validates all models files in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+<a name="module_concerto-core.ModelManager+updateExternalModels"></a>
+
+#### modelManager.updateExternalModels([options], [modelFileDownloader]) ⇒ <code>Promise</code>
+Downloads all ModelFiles that are external dependencies and adds or
+updates them in this ModelManager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Promise</code> - a promise when the download and update operation is completed.  
+**Throws**:
+
+- <code>IllegalModelException</code> if the models fail validation
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>Object</code> | Options object passed to ModelFileLoaders |
+| [modelFileDownloader] | <code>ModelFileDownloader</code> | an optional ModelFileDownloader |
+
+<a name="module_concerto-core.ModelManager+writeModelsToFileSystem"></a>
+
+#### modelManager.writeModelsToFileSystem(path, [options])
+Write all models in this model manager to the specified path in the file system
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| path | <code>String</code> | to a local directory |
+| [options] | <code>Object</code> | Options object |
+| options.includeExternalModels | <code>boolean</code> | If true, external models are written to the file system. Defaults to true |
+| options.includeSystemModels | <code>boolean</code> | If true, system models are written to the file system. Defaults to false |
+
+<a name="module_concerto-core.ModelManager+getModels"></a>
+
+#### modelManager.getModels([options]) ⇒ <code>Array.&lt;{name:string, content:string}&gt;</code>
+Gets all the CTO models
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;{name:string, content:string}&gt;</code> - the name and content of each CTO file  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>Object</code> | Options object |
+| options.includeExternalModels | <code>boolean</code> | If true, external models are written to the file system. Defaults to true |
+| options.includeSystemModels | <code>boolean</code> | If true, system models are written to the file system. Defaults to false |
+
+<a name="module_concerto-core.ModelManager+clearModelFiles"></a>
+
+#### modelManager.clearModelFiles()
+Remove all registered Concerto files
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+<a name="module_concerto-core.ModelManager+getNamespaces"></a>
+
+#### modelManager.getNamespaces() ⇒ <code>Array.&lt;string&gt;</code>
+Get the namespaces registered with the ModelManager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;string&gt;</code> - namespaces - the namespaces that have been registered.  
+<a name="module_concerto-core.ModelManager+getSystemTypes"></a>
+
+#### modelManager.getSystemTypes() ⇒ <code>Array.&lt;ClassDeclaration&gt;</code>
+Get all class declarations from system namespaces
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;ClassDeclaration&gt;</code> - the ClassDeclarations from system namespaces  
+<a name="module_concerto-core.ModelManager+getAssetDeclarations"></a>
+
+#### modelManager.getAssetDeclarations(includeSystemType) ⇒ <code>Array.&lt;AssetDeclaration&gt;</code>
+Get the AssetDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;AssetDeclaration&gt;</code> - the AssetDeclarations defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getTransactionDeclarations"></a>
+
+#### modelManager.getTransactionDeclarations(includeSystemType) ⇒ <code>Array.&lt;TransactionDeclaration&gt;</code>
+Get the TransactionDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;TransactionDeclaration&gt;</code> - the TransactionDeclarations defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getEventDeclarations"></a>
+
+#### modelManager.getEventDeclarations(includeSystemType) ⇒ <code>Array.&lt;EventDeclaration&gt;</code>
+Get the EventDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;EventDeclaration&gt;</code> - the EventDeclaration defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getParticipantDeclarations"></a>
+
+#### modelManager.getParticipantDeclarations(includeSystemType) ⇒ <code>Array.&lt;ParticipantDeclaration&gt;</code>
+Get the ParticipantDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;ParticipantDeclaration&gt;</code> - the ParticipantDeclaration defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getEnumDeclarations"></a>
+
+#### modelManager.getEnumDeclarations(includeSystemType) ⇒ <code>Array.&lt;EnumDeclaration&gt;</code>
+Get the EnumDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;EnumDeclaration&gt;</code> - the EnumDeclaration defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getConceptDeclarations"></a>
+
+#### modelManager.getConceptDeclarations(includeSystemType) ⇒ <code>Array.&lt;ConceptDeclaration&gt;</code>
+Get the Concepts defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;ConceptDeclaration&gt;</code> - the ConceptDeclaration defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getFactory"></a>
+
+#### modelManager.getFactory() ⇒ <code>Factory</code>
+Get a factory for creating new instances of types defined in this model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Factory</code> - A factory for creating new instances of types defined in this model manager.  
+<a name="module_concerto-core.ModelManager+getSerializer"></a>
+
+#### modelManager.getSerializer() ⇒ <code>Serializer</code>
+Get a serializer for serializing instances of types defined in this model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Serializer</code> - A serializer for serializing instances of types defined in this model manager.  
+<a name="module_concerto-core.ModelManager+getDecoratorFactories"></a>
+
+#### modelManager.getDecoratorFactories() ⇒ <code>Array.&lt;DecoratorFactory&gt;</code>
+Get the decorator factories for this model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;DecoratorFactory&gt;</code> - The decorator factories for this model manager.  
+<a name="module_concerto-core.ModelManager+addDecoratorFactory"></a>
+
+#### modelManager.addDecoratorFactory(factory)
+Add a decorator factory to this model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| factory | <code>DecoratorFactory</code> | The decorator factory to add to this model manager. |
+
+<a name="module_concerto-core.ModelManager.Symbol.hasInstance"></a>
+
+#### ModelManager.Symbol.hasInstance(object) ⇒ <code>boolean</code>
+Alternative instanceof that is reliable across different module instances
+
+**Kind**: static method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>boolean</code> - - True, if the object is an instance of a ModelManager  
+**See**: https://github.com/hyperledger/composer-concerto/issues/47  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| object | <code>object</code> | The object to test against |
+
+<a name="module_concerto-core.SecurityException"></a>
+
+### concerto-core~SecurityException ⇐ <code>BaseException</code>
+Class representing a security exception
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+**Extends**: <code>BaseException</code>  
+**See**: See [BaseException](BaseException)  
+<a name="new_module_concerto-core.SecurityException_new"></a>
+
+#### new SecurityException(message)
+Create the SecurityException.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>string</code> | The exception message. |
+
+<a name="module_concerto-core.Serializer"></a>
+
+### concerto-core~Serializer
+Serialize Resources instances to/from various formats for long-term storage
+(e.g. on the blockchain).
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+
+* [~Serializer](#module_concerto-core.Serializer)
+    * [new Serializer(factory, modelManager)](#new_module_concerto-core.Serializer_new)
+    * _instance_
+        * [.setDefaultOptions(newDefaultOptions)](#module_concerto-core.Serializer+setDefaultOptions)
+        * [.toJSON(resource, [options])](#module_concerto-core.Serializer+toJSON) ⇒ <code>Object</code>
+        * [.fromJSON(jsonObject, options)](#module_concerto-core.Serializer+fromJSON) ⇒ <code>Resource</code>
+    * _static_
+        * [.Symbol.hasInstance(object)](#module_concerto-core.Serializer.Symbol.hasInstance) ⇒ <code>boolean</code>
+
+<a name="new_module_concerto-core.Serializer_new"></a>
+
+#### new Serializer(factory, modelManager)
+Create a Serializer.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| factory | <code>Factory</code> | The Factory to use to create instances |
+| modelManager | <code>ModelManager</code> | The ModelManager to use for validation etc. |
+
+<a name="module_concerto-core.Serializer+setDefaultOptions"></a>
+
+#### serializer.setDefaultOptions(newDefaultOptions)
+Set the default options for the serializer.
+
+**Kind**: instance method of [<code>Serializer</code>](#module_concerto-core.Serializer)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| newDefaultOptions | <code>Object</code> | The new default options for the serializer. |
+
+<a name="module_concerto-core.Serializer+toJSON"></a>
+
+#### serializer.toJSON(resource, [options]) ⇒ <code>Object</code>
+<p>
+Convert a [Resource](Resource) to a JavaScript object suitable for long-term
+peristent storage.
+</p>
+
+**Kind**: instance method of [<code>Serializer</code>](#module_concerto-core.Serializer)  
+**Returns**: <code>Object</code> - - The Javascript Object that represents the resource  
+**Throws**:
+
+- <code>Error</code> - throws an exception if resource is not an instance of
+Resource or fails validation.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| resource | <code>Resource</code> | The instance to convert to JSON |
+| [options] | <code>Object</code> | the optional serialization options. |
+| [options.validate] | <code>boolean</code> | validate the structure of the Resource with its model prior to serialization (default to true) |
+| [options.convertResourcesToRelationships] | <code>boolean</code> | Convert resources that are specified for relationship fields into relationships, false by default. |
+| [options.permitResourcesForRelationships] | <code>boolean</code> | Permit resources in the place of relationships (serializing them as resources), false by default. |
+| [options.deduplicateResources] | <code>boolean</code> | Generate $id for resources and if a resources appears multiple times in the object graph only the first instance is serialized in full, subsequent instances are replaced with a reference to the $id |
+| [options.convertResourcesToId] | <code>boolean</code> | Convert resources that are specified for relationship fields into their id, false by default. |
+
+<a name="module_concerto-core.Serializer+fromJSON"></a>
+
+#### serializer.fromJSON(jsonObject, options) ⇒ <code>Resource</code>
+Create a [Resource](Resource) from a JavaScript Object representation.
+The JavaScript Object should have been created by calling the
+[toJSON](Serializer#toJSON) API.
+
+The Resource is populated based on the JavaScript object.
+
+**Kind**: instance method of [<code>Serializer</code>](#module_concerto-core.Serializer)  
+**Returns**: <code>Resource</code> - The new populated resource  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| jsonObject | <code>Object</code> | The JavaScript Object for a Resource |
+| options | <code>Object</code> | the optional serialization options |
+| options.acceptResourcesForRelationships | <code>boolean</code> | handle JSON objects in the place of strings for relationships, defaults to false. |
+| options.validate | <code>boolean</code> | validate the structure of the Resource with its model prior to serialization (default to true) |
+
+<a name="module_concerto-core.Serializer.Symbol.hasInstance"></a>
+
+#### Serializer.Symbol.hasInstance(object) ⇒ <code>boolean</code>
+Alternative instanceof that is reliable across different module instances
+
+**Kind**: static method of [<code>Serializer</code>](#module_concerto-core.Serializer)  
+**Returns**: <code>boolean</code> - - True, if the object is an instance of a Serializer  
+**See**: https://github.com/hyperledger/composer-concerto/issues/47  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| object | <code>object</code> | The object to test against |
 
 <a name="module_concerto-core.AssetDeclaration"></a>
 

--- a/website/scripts/build_api_md.sh
+++ b/website/scripts/build_api_md.sh
@@ -13,13 +13,13 @@
 # limitations under the License.
 #
 
-## Build the Cicero API
+# Build the Cicero API
 git clone https://github.com/accordproject/cicero.git
-./node_modules/.bin/jsdoc2md --files ./cicero/packages/cicero-engine/index.js ./cicero/packages/cicero-engine/lib/*.js ./cicero/packages/cicero-core/index.js ./cicero/packages/cicero-core/src/*.js > ../docs/cicero-api.md
-./node_modules/.bin/jsdoc2md --template ./scripts/cicero-api.hbs --files ./cicero/packages/cicero-engine/index.js ./cicero/packages/cicero-engine/lib/*.js ./cicero/packages/cicero-core/index.js ./cicero/packages/cicero-core/src/*.js > ../docs/cicero-api.md
+./node_modules/.bin/jsdoc2md -c ./scripts/cicero-jsdoc.conf --files ./cicero/packages/cicero-engine/{*,lib/*,lib/**/*}.js ./cicero/packages/cicero-core/{*,src/*,src/**/*}.js > ../docs/cicero-api.md
+./node_modules/.bin/jsdoc2md --template ./scripts/cicero-api.hbs -c ./scripts/cicero-jsdoc.conf --files ./cicero/packages/cicero-engine/{*,lib/*,lib/**/*}.js ./cicero/packages/cicero-core/{*,src/*,src/**/*}.js > ../docs/cicero-api.md
 rm -rf cicero
 
-## Build the Ergo API
+# Build the Ergo API
 git clone https://github.com/accordproject/ergo.git
 ./node_modules/.bin/jsdoc2md -c ./scripts/ergo-jsdoc.conf --files ./ergo/packages/**/lib/*.js > ../docs/ergo-api.md
 ./node_modules/.bin/jsdoc2md --template ./scripts/ergo-api.hbs -c ./scripts/ergo-jsdoc.conf --files ./ergo/packages/**/lib/*.js > ../docs/ergo-api.md
@@ -27,6 +27,6 @@ rm -rf ergo
 
 ## Build the Concerto API
 git clone https://github.com/accordproject/concerto.git
-./node_modules/.bin/jsdoc2md --files ./concerto/packages/concerto-core/index.js ./concerto/packages/concerto-core/lib/**/*.js > ../docs/concerto-api.md
-./node_modules/.bin/jsdoc2md --template ./scripts/concerto-api.hbs --files ./concerto/packages/concerto-core/index.js ./concerto/packages/concerto-core/lib/**/*.js > ../docs/concerto-api.md
+./node_modules/.bin/jsdoc2md -c ./scripts/concerto-jsdoc.conf --files ./concerto/packages/concerto-core/{*,lib/*,lib/**/*}.js > ../docs/concerto-api.md
+./node_modules/.bin/jsdoc2md --template ./scripts/concerto-api.hbs -c ./scripts/concerto-jsdoc.conf --files ./concerto/packages/concerto-core/{*,lib/*,lib/**/*}.js > ../docs/concerto-api.md
 rm -rf concerto

--- a/website/scripts/concerto-jsdoc.conf
+++ b/website/scripts/concerto-jsdoc.conf
@@ -2,7 +2,7 @@
     "plugins": [],
     "recurseDepth": 10,
     "source": {
-        "includePattern": ".+\\.js(doc|x)?$"
+        "includePattern": ".+\\.js(doc|x)?$",
         "excludePattern": "(.+\/concerto-cli\/.+$)|(.+\/test\/.+$)"
     },
     "sourceType": "module",

--- a/website/versioned_docs/version-0.20/cicero-api.md
+++ b/website/versioned_docs/version-0.20/cicero-api.md
@@ -51,6 +51,10 @@ A TemplateInstance must be constructed with a template and then prior to executi
 Set the data for the TemplateInstance by either calling the setData method or by
 calling the parse method and passing in natural language text that conforms to the template grammar.</p>
 </dd>
+<dt><a href="#CompositeArchiveLoader">CompositeArchiveLoader</a></dt>
+<dd><p>Manages a set of archive loaders, delegating to the first archive
+loader that accepts a URL.</p>
+</dd>
 </dl>
 
 ## Functions
@@ -1032,6 +1036,68 @@ to a Moment.
 | --- | --- | --- |
 | obj | <code>\*</code> | the input object |
 | utcOffset | <code>number</code> | the default utcOffset |
+
+<a name="CompositeArchiveLoader"></a>
+
+## CompositeArchiveLoader
+Manages a set of archive loaders, delegating to the first archive
+loader that accepts a URL.
+
+**Kind**: global class  
+
+* [CompositeArchiveLoader](#CompositeArchiveLoader)
+    * [new CompositeArchiveLoader()](#new_CompositeArchiveLoader_new)
+    * [.addArchiveLoader(archiveLoader)](#CompositeArchiveLoader+addArchiveLoader)
+    * [.clearArchiveLoaders()](#CompositeArchiveLoader+clearArchiveLoaders)
+    * *[.accepts(url)](#CompositeArchiveLoader+accepts) ⇒ <code>boolean</code>*
+    * [.load(url, options)](#CompositeArchiveLoader+load) ⇒ <code>Promise</code>
+
+<a name="new_CompositeArchiveLoader_new"></a>
+
+### new CompositeArchiveLoader()
+Create the CompositeArchiveLoader. Used to delegate to a set of ArchiveLoaders.
+
+<a name="CompositeArchiveLoader+addArchiveLoader"></a>
+
+### compositeArchiveLoader.addArchiveLoader(archiveLoader)
+Adds a ArchiveLoader implemenetation to the ArchiveLoader
+
+**Kind**: instance method of [<code>CompositeArchiveLoader</code>](#CompositeArchiveLoader)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| archiveLoader | <code>ArchiveLoader</code> | The archive to add to the CompositeArchiveLoader |
+
+<a name="CompositeArchiveLoader+clearArchiveLoaders"></a>
+
+### compositeArchiveLoader.clearArchiveLoaders()
+Remove all registered ArchiveLoaders
+
+**Kind**: instance method of [<code>CompositeArchiveLoader</code>](#CompositeArchiveLoader)  
+<a name="CompositeArchiveLoader+accepts"></a>
+
+### *compositeArchiveLoader.accepts(url) ⇒ <code>boolean</code>*
+Returns true if this ArchiveLoader can process the URL
+
+**Kind**: instance abstract method of [<code>CompositeArchiveLoader</code>](#CompositeArchiveLoader)  
+**Returns**: <code>boolean</code> - true if this ArchiveLoader accepts the URL  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | the URL |
+
+<a name="CompositeArchiveLoader+load"></a>
+
+### compositeArchiveLoader.load(url, options) ⇒ <code>Promise</code>
+Load a Archive from a URL and return it
+
+**Kind**: instance method of [<code>CompositeArchiveLoader</code>](#CompositeArchiveLoader)  
+**Returns**: <code>Promise</code> - a promise to the Archive  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | the url to get |
+| options | <code>object</code> | additional options |
 
 <a name="locationOfError"></a>
 

--- a/website/versioned_docs/version-0.20/concerto-api.md
+++ b/website/versioned_docs/version-0.20/concerto-api.md
@@ -13,9 +13,65 @@ specific models.
 
 * [concerto-core](#module_concerto-core)
     * _static_
+        * [.ModelLoader](#module_concerto-core.ModelLoader)
+            * [.loadModelManager(ctoSystemFile, ctoFiles)](#module_concerto-core.ModelLoader.loadModelManager) ⇒ <code>object</code>
         * [.DecoratorFactory](#module_concerto-core.DecoratorFactory)
             * *[.newDecorator(parent, ast)](#module_concerto-core.DecoratorFactory+newDecorator) ⇒ <code>Decorator</code>*
     * _inner_
+        * [~BaseException](#module_concerto-core.BaseException) ⇐ <code>Error</code>
+            * [new BaseException(message, component)](#new_module_concerto-core.BaseException_new)
+        * [~BaseFileException](#module_concerto-core.BaseFileException) ⇐ <code>BaseException</code>
+            * [new BaseFileException(message, fileLocation, fullMessage, fileName, component)](#new_module_concerto-core.BaseFileException_new)
+            * [.getFileLocation()](#module_concerto-core.BaseFileException+getFileLocation) ⇒ <code>string</code>
+            * [.getShortMessage()](#module_concerto-core.BaseFileException+getShortMessage) ⇒ <code>string</code>
+            * [.getFileName()](#module_concerto-core.BaseFileException+getFileName) ⇒ <code>string</code>
+        * [~Factory](#module_concerto-core.Factory)
+            * [new Factory(modelManager)](#new_module_concerto-core.Factory_new)
+            * _instance_
+                * [.newResource(ns, type, id, [options])](#module_concerto-core.Factory+newResource) ⇒ <code>Resource</code>
+                * [.newConcept(ns, type, [options])](#module_concerto-core.Factory+newConcept) ⇒ <code>Resource</code>
+                * [.newRelationship(ns, type, id)](#module_concerto-core.Factory+newRelationship) ⇒ <code>Relationship</code>
+                * [.newTransaction(ns, type, [id], [options])](#module_concerto-core.Factory+newTransaction) ⇒ <code>Resource</code>
+                * [.newEvent(ns, type, [id], [options])](#module_concerto-core.Factory+newEvent) ⇒ <code>Resource</code>
+            * _static_
+                * [.Symbol.hasInstance(object)](#module_concerto-core.Factory.Symbol.hasInstance) ⇒ <code>boolean</code>
+        * [~ModelManager](#module_concerto-core.ModelManager)
+            * [new ModelManager()](#new_module_concerto-core.ModelManager_new)
+            * _instance_
+                * [.validateModelFile(modelFile, fileName)](#module_concerto-core.ModelManager+validateModelFile)
+                * [.addModelFile(modelFile, fileName, [disableValidation], [systemModelTable])](#module_concerto-core.ModelManager+addModelFile) ⇒ <code>Object</code>
+                * [.updateModelFile(modelFile, fileName, [disableValidation])](#module_concerto-core.ModelManager+updateModelFile) ⇒ <code>Object</code>
+                * [.deleteModelFile(namespace)](#module_concerto-core.ModelManager+deleteModelFile)
+                * [.addModelFiles(modelFiles, [fileNames], [disableValidation], [systemModelTable])](#module_concerto-core.ModelManager+addModelFiles) ⇒ <code>Array.&lt;Object&gt;</code>
+                * [.validateModelFiles()](#module_concerto-core.ModelManager+validateModelFiles)
+                * [.updateExternalModels([options], [modelFileDownloader])](#module_concerto-core.ModelManager+updateExternalModels) ⇒ <code>Promise</code>
+                * [.writeModelsToFileSystem(path, [options])](#module_concerto-core.ModelManager+writeModelsToFileSystem)
+                * [.getModels([options])](#module_concerto-core.ModelManager+getModels) ⇒ <code>Array.&lt;{name:string, content:string}&gt;</code>
+                * [.clearModelFiles()](#module_concerto-core.ModelManager+clearModelFiles)
+                * [.getNamespaces()](#module_concerto-core.ModelManager+getNamespaces) ⇒ <code>Array.&lt;string&gt;</code>
+                * [.getSystemTypes()](#module_concerto-core.ModelManager+getSystemTypes) ⇒ <code>Array.&lt;ClassDeclaration&gt;</code>
+                * [.getAssetDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getAssetDeclarations) ⇒ <code>Array.&lt;AssetDeclaration&gt;</code>
+                * [.getTransactionDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getTransactionDeclarations) ⇒ <code>Array.&lt;TransactionDeclaration&gt;</code>
+                * [.getEventDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getEventDeclarations) ⇒ <code>Array.&lt;EventDeclaration&gt;</code>
+                * [.getParticipantDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getParticipantDeclarations) ⇒ <code>Array.&lt;ParticipantDeclaration&gt;</code>
+                * [.getEnumDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getEnumDeclarations) ⇒ <code>Array.&lt;EnumDeclaration&gt;</code>
+                * [.getConceptDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getConceptDeclarations) ⇒ <code>Array.&lt;ConceptDeclaration&gt;</code>
+                * [.getFactory()](#module_concerto-core.ModelManager+getFactory) ⇒ <code>Factory</code>
+                * [.getSerializer()](#module_concerto-core.ModelManager+getSerializer) ⇒ <code>Serializer</code>
+                * [.getDecoratorFactories()](#module_concerto-core.ModelManager+getDecoratorFactories) ⇒ <code>Array.&lt;DecoratorFactory&gt;</code>
+                * [.addDecoratorFactory(factory)](#module_concerto-core.ModelManager+addDecoratorFactory)
+            * _static_
+                * [.Symbol.hasInstance(object)](#module_concerto-core.ModelManager.Symbol.hasInstance) ⇒ <code>boolean</code>
+        * [~SecurityException](#module_concerto-core.SecurityException) ⇐ <code>BaseException</code>
+            * [new SecurityException(message)](#new_module_concerto-core.SecurityException_new)
+        * [~Serializer](#module_concerto-core.Serializer)
+            * [new Serializer(factory, modelManager)](#new_module_concerto-core.Serializer_new)
+            * _instance_
+                * [.setDefaultOptions(newDefaultOptions)](#module_concerto-core.Serializer+setDefaultOptions)
+                * [.toJSON(resource, [options])](#module_concerto-core.Serializer+toJSON) ⇒ <code>Object</code>
+                * [.fromJSON(jsonObject, options)](#module_concerto-core.Serializer+fromJSON) ⇒ <code>Resource</code>
+            * _static_
+                * [.Symbol.hasInstance(object)](#module_concerto-core.Serializer.Symbol.hasInstance) ⇒ <code>boolean</code>
         * [~AssetDeclaration](#module_concerto-core.AssetDeclaration) ⇐ <code>ClassDeclaration</code>
             * [new AssetDeclaration(modelFile, ast)](#new_module_concerto-core.AssetDeclaration_new)
             * _instance_
@@ -145,6 +201,27 @@ specific models.
             * _static_
                 * [.Symbol.hasInstance(object)](#module_concerto-core.TransactionDeclaration.Symbol.hasInstance) ⇒ <code>boolean</code>
 
+<a name="module_concerto-core.ModelLoader"></a>
+
+### concerto-core.ModelLoader
+Create a ModelManager from model files, with an optional system model.
+
+If a ctoFile is not provided, the Accord Project system model is used.
+
+**Kind**: static class of [<code>concerto-core</code>](#module_concerto-core)  
+<a name="module_concerto-core.ModelLoader.loadModelManager"></a>
+
+#### ModelLoader.loadModelManager(ctoSystemFile, ctoFiles) ⇒ <code>object</code>
+Load system and models in a new model manager
+
+**Kind**: static method of [<code>ModelLoader</code>](#module_concerto-core.ModelLoader)  
+**Returns**: <code>object</code> - the model manager  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ctoSystemFile | <code>string</code> | the system model file |
+| ctoFiles | <code>Array.&lt;string&gt;</code> | the CTO files (can be local file paths or URLs) |
+
 <a name="module_concerto-core.DecoratorFactory"></a>
 
 ### concerto-core.DecoratorFactory
@@ -165,6 +242,668 @@ decorator, or return null if this decorator is not handled by this processor.
 | --- | --- | --- |
 | parent | <code>ClassDeclaration</code> \| <code>Property</code> | the owner of this property |
 | ast | <code>Object</code> | The AST created by the parser |
+
+<a name="module_concerto-core.BaseException"></a>
+
+### concerto-core~BaseException ⇐ <code>Error</code>
+A base class for all Concerto exceptions
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+**Extends**: <code>Error</code>  
+<a name="new_module_concerto-core.BaseException_new"></a>
+
+#### new BaseException(message, component)
+Create the BaseException.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>string</code> | The exception message. |
+| component | <code>string</code> | The optional component which throws this error. |
+
+<a name="module_concerto-core.BaseFileException"></a>
+
+### concerto-core~BaseFileException ⇐ <code>BaseException</code>
+Exception throws when a Concerto file is semantically invalid
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+**Extends**: <code>BaseException</code>  
+**See**: [BaseException](BaseException)  
+
+* [~BaseFileException](#module_concerto-core.BaseFileException) ⇐ <code>BaseException</code>
+    * [new BaseFileException(message, fileLocation, fullMessage, fileName, component)](#new_module_concerto-core.BaseFileException_new)
+    * [.getFileLocation()](#module_concerto-core.BaseFileException+getFileLocation) ⇒ <code>string</code>
+    * [.getShortMessage()](#module_concerto-core.BaseFileException+getShortMessage) ⇒ <code>string</code>
+    * [.getFileName()](#module_concerto-core.BaseFileException+getFileName) ⇒ <code>string</code>
+
+<a name="new_module_concerto-core.BaseFileException_new"></a>
+
+#### new BaseFileException(message, fileLocation, fullMessage, fileName, component)
+Create an BaseFileException
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>string</code> | the message for the exception |
+| fileLocation | <code>string</code> | the optional file location associated with the exception |
+| fullMessage | <code>string</code> | the optional full message text |
+| fileName | <code>string</code> | the optional file name |
+| component | <code>string</code> | the optional component which throws this error |
+
+<a name="module_concerto-core.BaseFileException+getFileLocation"></a>
+
+#### baseFileException.getFileLocation() ⇒ <code>string</code>
+Returns the file location associated with the exception or null
+
+**Kind**: instance method of [<code>BaseFileException</code>](#module_concerto-core.BaseFileException)  
+**Returns**: <code>string</code> - the optional location associated with the exception  
+<a name="module_concerto-core.BaseFileException+getShortMessage"></a>
+
+#### baseFileException.getShortMessage() ⇒ <code>string</code>
+Returns the error message without the location of the error
+
+**Kind**: instance method of [<code>BaseFileException</code>](#module_concerto-core.BaseFileException)  
+**Returns**: <code>string</code> - the error message  
+<a name="module_concerto-core.BaseFileException+getFileName"></a>
+
+#### baseFileException.getFileName() ⇒ <code>string</code>
+Returns the fileName for the error
+
+**Kind**: instance method of [<code>BaseFileException</code>](#module_concerto-core.BaseFileException)  
+**Returns**: <code>string</code> - the file name or null  
+<a name="module_concerto-core.Factory"></a>
+
+### concerto-core~Factory
+Use the Factory to create instances of Resource: transactions, participants
+and assets.
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+
+* [~Factory](#module_concerto-core.Factory)
+    * [new Factory(modelManager)](#new_module_concerto-core.Factory_new)
+    * _instance_
+        * [.newResource(ns, type, id, [options])](#module_concerto-core.Factory+newResource) ⇒ <code>Resource</code>
+        * [.newConcept(ns, type, [options])](#module_concerto-core.Factory+newConcept) ⇒ <code>Resource</code>
+        * [.newRelationship(ns, type, id)](#module_concerto-core.Factory+newRelationship) ⇒ <code>Relationship</code>
+        * [.newTransaction(ns, type, [id], [options])](#module_concerto-core.Factory+newTransaction) ⇒ <code>Resource</code>
+        * [.newEvent(ns, type, [id], [options])](#module_concerto-core.Factory+newEvent) ⇒ <code>Resource</code>
+    * _static_
+        * [.Symbol.hasInstance(object)](#module_concerto-core.Factory.Symbol.hasInstance) ⇒ <code>boolean</code>
+
+<a name="new_module_concerto-core.Factory_new"></a>
+
+#### new Factory(modelManager)
+Create the factory.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelManager | <code>ModelManager</code> | The ModelManager to use for this registry |
+
+<a name="module_concerto-core.Factory+newResource"></a>
+
+#### factory.newResource(ns, type, id, [options]) ⇒ <code>Resource</code>
+Create a new Resource with a given namespace, type name and id
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Resource</code> - the new instance  
+**Throws**:
+
+- <code>TypeNotFoundException</code> if the type is not registered with the ModelManager
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the Resource |
+| type | <code>String</code> | the type of the Resource |
+| id | <code>String</code> | the identifier |
+| [options] | <code>Object</code> | an optional set of options |
+| [options.disableValidation] | <code>boolean</code> | pass true if you want the factory to return a [Resource](Resource) instead of a [ValidatedResource](ValidatedResource). Defaults to false. |
+| [options.generate] | <code>String</code> | Pass one of: <dl> <dt>sample</dt><dd>return a resource instance with generated sample data.</dd> <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl> |
+| [options.includeOptionalFields] | <code>boolean</code> | if <code>options.generate</code> is specified, whether optional fields should be generated. |
+| [options.allowEmptyId] | <code>boolean</code> | if <code>options.allowEmptyId</code> is specified as true, a zero length string for id is allowed (allows it to be filled in later). |
+
+<a name="module_concerto-core.Factory+newConcept"></a>
+
+#### factory.newConcept(ns, type, [options]) ⇒ <code>Resource</code>
+Create a new Concept with a given namespace and type name
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Resource</code> - the new instance  
+**Throws**:
+
+- <code>TypeNotFoundException</code> if the type is not registered with the ModelManager
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the Concept |
+| type | <code>String</code> | the type of the Concept |
+| [options] | <code>Object</code> | an optional set of options |
+| [options.disableValidation] | <code>boolean</code> | pass true if you want the factory to return a [Concept](Concept) instead of a [ValidatedConcept](ValidatedConcept). Defaults to false. |
+| [options.generate] | <code>String</code> | Pass one of: <dl> <dt>sample</dt><dd>return a resource instance with generated sample data.</dd> <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl> |
+| [options.includeOptionalFields] | <code>boolean</code> | if <code>options.generate</code> is specified, whether optional fields should be generated. |
+
+<a name="module_concerto-core.Factory+newRelationship"></a>
+
+#### factory.newRelationship(ns, type, id) ⇒ <code>Relationship</code>
+Create a new Relationship with a given namespace, type and identifier.
+A relationship is a typed pointer to an instance. I.e the relationship
+with `namespace = 'org.example'`, `type = 'Vehicle'` and `id = 'ABC' creates`
+a pointer that points at an instance of org.example.Vehicle with the id
+ABC.
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Relationship</code> - - the new relationship instance  
+**Throws**:
+
+- <code>TypeNotFoundException</code> if the type is not registered with the ModelManager
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the Resource |
+| type | <code>String</code> | the type of the Resource |
+| id | <code>String</code> | the identifier |
+
+<a name="module_concerto-core.Factory+newTransaction"></a>
+
+#### factory.newTransaction(ns, type, [id], [options]) ⇒ <code>Resource</code>
+Create a new transaction object. The identifier of the transaction is
+set to a UUID.
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Resource</code> - A resource for the new transaction.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the transaction. |
+| type | <code>String</code> | the type of the transaction. |
+| [id] | <code>String</code> | an optional identifier for the transaction; if you do not specify one then an identifier will be automatically generated. |
+| [options] | <code>Object</code> | an optional set of options |
+| [options.generate] | <code>String</code> | Pass one of: <dl> <dt>sample</dt><dd>return a resource instance with generated sample data.</dd> <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl> |
+| [options.includeOptionalFields] | <code>boolean</code> | if <code>options.generate</code> is specified, whether optional fields should be generated. |
+| [options.allowEmptyId] | <code>boolean</code> | if <code>options.allowEmptyId</code> is specified as true, a zero length string for id is allowed (allows it to be filled in later). |
+
+<a name="module_concerto-core.Factory+newEvent"></a>
+
+#### factory.newEvent(ns, type, [id], [options]) ⇒ <code>Resource</code>
+Create a new event object. The identifier of the event is
+set to a UUID.
+
+**Kind**: instance method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>Resource</code> - A resource for the new event.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| ns | <code>String</code> | the namespace of the event. |
+| type | <code>String</code> | the type of the event. |
+| [id] | <code>String</code> | an optional identifier for the event; if you do not specify one then an identifier will be automatically generated. |
+| [options] | <code>Object</code> | an optional set of options |
+| [options.generate] | <code>String</code> | Pass one of: <dl> <dt>sample</dt><dd>return a resource instance with generated sample data.</dd> <dt>empty</dt><dd>return a resource instance with empty property values.</dd></dl> |
+| [options.includeOptionalFields] | <code>boolean</code> | if <code>options.generate</code> is specified, whether optional fields should be generated. |
+| [options.allowEmptyId] | <code>boolean</code> | if <code>options.allowEmptyId</code> is specified as true, a zero length string for id is allowed (allows it to be filled in later). |
+
+<a name="module_concerto-core.Factory.Symbol.hasInstance"></a>
+
+#### Factory.Symbol.hasInstance(object) ⇒ <code>boolean</code>
+Alternative instanceof that is reliable across different module instances
+
+**Kind**: static method of [<code>Factory</code>](#module_concerto-core.Factory)  
+**Returns**: <code>boolean</code> - - True, if the object is an instance of a Factory  
+**See**: https://github.com/hyperledger/composer-concerto/issues/47  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| object | <code>object</code> | The object to test against |
+
+<a name="module_concerto-core.ModelManager"></a>
+
+### concerto-core~ModelManager
+Manages the Concerto model files.
+
+The structure of [Resource](Resource)s (Assets, Transactions, Participants) is modelled
+in a set of Concerto files. The contents of these files are managed
+by the [ModelManager](ModelManager). Each Concerto file has a single namespace and contains
+a set of asset, transaction and participant type definitions.
+
+Concerto applications load their Concerto files and then call the [addModelFile](ModelManager#addModelFile)
+method to register the Concerto file(s) with the ModelManager. The ModelManager
+parses the text of the Concerto file and will make all defined types available
+to other Concerto services, such as the [Serializer](Serializer) (to convert instances to/from JSON)
+and [Factory](Factory) (to create instances).
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+
+* [~ModelManager](#module_concerto-core.ModelManager)
+    * [new ModelManager()](#new_module_concerto-core.ModelManager_new)
+    * _instance_
+        * [.validateModelFile(modelFile, fileName)](#module_concerto-core.ModelManager+validateModelFile)
+        * [.addModelFile(modelFile, fileName, [disableValidation], [systemModelTable])](#module_concerto-core.ModelManager+addModelFile) ⇒ <code>Object</code>
+        * [.updateModelFile(modelFile, fileName, [disableValidation])](#module_concerto-core.ModelManager+updateModelFile) ⇒ <code>Object</code>
+        * [.deleteModelFile(namespace)](#module_concerto-core.ModelManager+deleteModelFile)
+        * [.addModelFiles(modelFiles, [fileNames], [disableValidation], [systemModelTable])](#module_concerto-core.ModelManager+addModelFiles) ⇒ <code>Array.&lt;Object&gt;</code>
+        * [.validateModelFiles()](#module_concerto-core.ModelManager+validateModelFiles)
+        * [.updateExternalModels([options], [modelFileDownloader])](#module_concerto-core.ModelManager+updateExternalModels) ⇒ <code>Promise</code>
+        * [.writeModelsToFileSystem(path, [options])](#module_concerto-core.ModelManager+writeModelsToFileSystem)
+        * [.getModels([options])](#module_concerto-core.ModelManager+getModels) ⇒ <code>Array.&lt;{name:string, content:string}&gt;</code>
+        * [.clearModelFiles()](#module_concerto-core.ModelManager+clearModelFiles)
+        * [.getNamespaces()](#module_concerto-core.ModelManager+getNamespaces) ⇒ <code>Array.&lt;string&gt;</code>
+        * [.getSystemTypes()](#module_concerto-core.ModelManager+getSystemTypes) ⇒ <code>Array.&lt;ClassDeclaration&gt;</code>
+        * [.getAssetDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getAssetDeclarations) ⇒ <code>Array.&lt;AssetDeclaration&gt;</code>
+        * [.getTransactionDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getTransactionDeclarations) ⇒ <code>Array.&lt;TransactionDeclaration&gt;</code>
+        * [.getEventDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getEventDeclarations) ⇒ <code>Array.&lt;EventDeclaration&gt;</code>
+        * [.getParticipantDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getParticipantDeclarations) ⇒ <code>Array.&lt;ParticipantDeclaration&gt;</code>
+        * [.getEnumDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getEnumDeclarations) ⇒ <code>Array.&lt;EnumDeclaration&gt;</code>
+        * [.getConceptDeclarations(includeSystemType)](#module_concerto-core.ModelManager+getConceptDeclarations) ⇒ <code>Array.&lt;ConceptDeclaration&gt;</code>
+        * [.getFactory()](#module_concerto-core.ModelManager+getFactory) ⇒ <code>Factory</code>
+        * [.getSerializer()](#module_concerto-core.ModelManager+getSerializer) ⇒ <code>Serializer</code>
+        * [.getDecoratorFactories()](#module_concerto-core.ModelManager+getDecoratorFactories) ⇒ <code>Array.&lt;DecoratorFactory&gt;</code>
+        * [.addDecoratorFactory(factory)](#module_concerto-core.ModelManager+addDecoratorFactory)
+    * _static_
+        * [.Symbol.hasInstance(object)](#module_concerto-core.ModelManager.Symbol.hasInstance) ⇒ <code>boolean</code>
+
+<a name="new_module_concerto-core.ModelManager_new"></a>
+
+#### new ModelManager()
+Create the ModelManager.
+
+<a name="module_concerto-core.ModelManager+validateModelFile"></a>
+
+#### modelManager.validateModelFile(modelFile, fileName)
+Validates a Concerto file (as a string) to the ModelManager.
+Concerto files have a single namespace.
+
+Note that if there are dependencies between multiple files the files
+must be added in dependency order, or the addModelFiles method can be
+used to add a set of files irrespective of dependencies.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Throws**:
+
+- <code>IllegalModelException</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelFile | <code>string</code> | The Concerto file as a string |
+| fileName | <code>string</code> | an optional file name to associate with the model file |
+
+<a name="module_concerto-core.ModelManager+addModelFile"></a>
+
+#### modelManager.addModelFile(modelFile, fileName, [disableValidation], [systemModelTable]) ⇒ <code>Object</code>
+Adds a Concerto file (as a string) to the ModelManager.
+Concerto files have a single namespace. If a Concerto file with the
+same namespace has already been added to the ModelManager then it
+will be replaced.
+Note that if there are dependencies between multiple files the files
+must be added in dependency order, or the addModelFiles method can be
+used to add a set of files irrespective of dependencies.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Object</code> - The newly added model file (internal).  
+**Throws**:
+
+- <code>IllegalModelException</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelFile | <code>string</code> | The Concerto file as a string |
+| fileName | <code>string</code> | an optional file name to associate with the model file |
+| [disableValidation] | <code>boolean</code> | If true then the model files are not validated |
+| [systemModelTable] | <code>boolean</code> | A table that maps classes in the new models to system types |
+
+<a name="module_concerto-core.ModelManager+updateModelFile"></a>
+
+#### modelManager.updateModelFile(modelFile, fileName, [disableValidation]) ⇒ <code>Object</code>
+Updates a Concerto file (as a string) on the ModelManager.
+Concerto files have a single namespace. If a Concerto file with the
+same namespace has already been added to the ModelManager then it
+will be replaced.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Object</code> - The newly added model file (internal).  
+**Throws**:
+
+- <code>IllegalModelException</code> 
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelFile | <code>string</code> | The Concerto file as a string |
+| fileName | <code>string</code> | an optional file name to associate with the model file |
+| [disableValidation] | <code>boolean</code> | If true then the model files are not validated |
+
+<a name="module_concerto-core.ModelManager+deleteModelFile"></a>
+
+#### modelManager.deleteModelFile(namespace)
+Remove the Concerto file for a given namespace
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| namespace | <code>string</code> | The namespace of the model file to delete. |
+
+<a name="module_concerto-core.ModelManager+addModelFiles"></a>
+
+#### modelManager.addModelFiles(modelFiles, [fileNames], [disableValidation], [systemModelTable]) ⇒ <code>Array.&lt;Object&gt;</code>
+Add a set of Concerto files to the model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;Object&gt;</code> - The newly added model files (internal).  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modelFiles | <code>Array.&lt;string&gt;</code> | An array of Concerto files as strings. |
+| [fileNames] | <code>Array.&lt;string&gt;</code> | An optional array of file names to associate with the model files |
+| [disableValidation] | <code>boolean</code> | If true then the model files are not validated |
+| [systemModelTable] | <code>boolean</code> | A table that maps classes in the new models to system types |
+
+<a name="module_concerto-core.ModelManager+validateModelFiles"></a>
+
+#### modelManager.validateModelFiles()
+Validates all models files in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+<a name="module_concerto-core.ModelManager+updateExternalModels"></a>
+
+#### modelManager.updateExternalModels([options], [modelFileDownloader]) ⇒ <code>Promise</code>
+Downloads all ModelFiles that are external dependencies and adds or
+updates them in this ModelManager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Promise</code> - a promise when the download and update operation is completed.  
+**Throws**:
+
+- <code>IllegalModelException</code> if the models fail validation
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>Object</code> | Options object passed to ModelFileLoaders |
+| [modelFileDownloader] | <code>ModelFileDownloader</code> | an optional ModelFileDownloader |
+
+<a name="module_concerto-core.ModelManager+writeModelsToFileSystem"></a>
+
+#### modelManager.writeModelsToFileSystem(path, [options])
+Write all models in this model manager to the specified path in the file system
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| path | <code>String</code> | to a local directory |
+| [options] | <code>Object</code> | Options object |
+| options.includeExternalModels | <code>boolean</code> | If true, external models are written to the file system. Defaults to true |
+| options.includeSystemModels | <code>boolean</code> | If true, system models are written to the file system. Defaults to false |
+
+<a name="module_concerto-core.ModelManager+getModels"></a>
+
+#### modelManager.getModels([options]) ⇒ <code>Array.&lt;{name:string, content:string}&gt;</code>
+Gets all the CTO models
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;{name:string, content:string}&gt;</code> - the name and content of each CTO file  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>Object</code> | Options object |
+| options.includeExternalModels | <code>boolean</code> | If true, external models are written to the file system. Defaults to true |
+| options.includeSystemModels | <code>boolean</code> | If true, system models are written to the file system. Defaults to false |
+
+<a name="module_concerto-core.ModelManager+clearModelFiles"></a>
+
+#### modelManager.clearModelFiles()
+Remove all registered Concerto files
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+<a name="module_concerto-core.ModelManager+getNamespaces"></a>
+
+#### modelManager.getNamespaces() ⇒ <code>Array.&lt;string&gt;</code>
+Get the namespaces registered with the ModelManager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;string&gt;</code> - namespaces - the namespaces that have been registered.  
+<a name="module_concerto-core.ModelManager+getSystemTypes"></a>
+
+#### modelManager.getSystemTypes() ⇒ <code>Array.&lt;ClassDeclaration&gt;</code>
+Get all class declarations from system namespaces
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;ClassDeclaration&gt;</code> - the ClassDeclarations from system namespaces  
+<a name="module_concerto-core.ModelManager+getAssetDeclarations"></a>
+
+#### modelManager.getAssetDeclarations(includeSystemType) ⇒ <code>Array.&lt;AssetDeclaration&gt;</code>
+Get the AssetDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;AssetDeclaration&gt;</code> - the AssetDeclarations defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getTransactionDeclarations"></a>
+
+#### modelManager.getTransactionDeclarations(includeSystemType) ⇒ <code>Array.&lt;TransactionDeclaration&gt;</code>
+Get the TransactionDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;TransactionDeclaration&gt;</code> - the TransactionDeclarations defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getEventDeclarations"></a>
+
+#### modelManager.getEventDeclarations(includeSystemType) ⇒ <code>Array.&lt;EventDeclaration&gt;</code>
+Get the EventDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;EventDeclaration&gt;</code> - the EventDeclaration defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getParticipantDeclarations"></a>
+
+#### modelManager.getParticipantDeclarations(includeSystemType) ⇒ <code>Array.&lt;ParticipantDeclaration&gt;</code>
+Get the ParticipantDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;ParticipantDeclaration&gt;</code> - the ParticipantDeclaration defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getEnumDeclarations"></a>
+
+#### modelManager.getEnumDeclarations(includeSystemType) ⇒ <code>Array.&lt;EnumDeclaration&gt;</code>
+Get the EnumDeclarations defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;EnumDeclaration&gt;</code> - the EnumDeclaration defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getConceptDeclarations"></a>
+
+#### modelManager.getConceptDeclarations(includeSystemType) ⇒ <code>Array.&lt;ConceptDeclaration&gt;</code>
+Get the Concepts defined in this model manager
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;ConceptDeclaration&gt;</code> - the ConceptDeclaration defined in the model manager  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| includeSystemType | <code>Boolean</code> | <code>true</code> | Include the decalarations of system type in returned data |
+
+<a name="module_concerto-core.ModelManager+getFactory"></a>
+
+#### modelManager.getFactory() ⇒ <code>Factory</code>
+Get a factory for creating new instances of types defined in this model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Factory</code> - A factory for creating new instances of types defined in this model manager.  
+<a name="module_concerto-core.ModelManager+getSerializer"></a>
+
+#### modelManager.getSerializer() ⇒ <code>Serializer</code>
+Get a serializer for serializing instances of types defined in this model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Serializer</code> - A serializer for serializing instances of types defined in this model manager.  
+<a name="module_concerto-core.ModelManager+getDecoratorFactories"></a>
+
+#### modelManager.getDecoratorFactories() ⇒ <code>Array.&lt;DecoratorFactory&gt;</code>
+Get the decorator factories for this model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>Array.&lt;DecoratorFactory&gt;</code> - The decorator factories for this model manager.  
+<a name="module_concerto-core.ModelManager+addDecoratorFactory"></a>
+
+#### modelManager.addDecoratorFactory(factory)
+Add a decorator factory to this model manager.
+
+**Kind**: instance method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| factory | <code>DecoratorFactory</code> | The decorator factory to add to this model manager. |
+
+<a name="module_concerto-core.ModelManager.Symbol.hasInstance"></a>
+
+#### ModelManager.Symbol.hasInstance(object) ⇒ <code>boolean</code>
+Alternative instanceof that is reliable across different module instances
+
+**Kind**: static method of [<code>ModelManager</code>](#module_concerto-core.ModelManager)  
+**Returns**: <code>boolean</code> - - True, if the object is an instance of a ModelManager  
+**See**: https://github.com/hyperledger/composer-concerto/issues/47  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| object | <code>object</code> | The object to test against |
+
+<a name="module_concerto-core.SecurityException"></a>
+
+### concerto-core~SecurityException ⇐ <code>BaseException</code>
+Class representing a security exception
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+**Extends**: <code>BaseException</code>  
+**See**: See [BaseException](BaseException)  
+<a name="new_module_concerto-core.SecurityException_new"></a>
+
+#### new SecurityException(message)
+Create the SecurityException.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>string</code> | The exception message. |
+
+<a name="module_concerto-core.Serializer"></a>
+
+### concerto-core~Serializer
+Serialize Resources instances to/from various formats for long-term storage
+(e.g. on the blockchain).
+
+**Kind**: inner class of [<code>concerto-core</code>](#module_concerto-core)  
+
+* [~Serializer](#module_concerto-core.Serializer)
+    * [new Serializer(factory, modelManager)](#new_module_concerto-core.Serializer_new)
+    * _instance_
+        * [.setDefaultOptions(newDefaultOptions)](#module_concerto-core.Serializer+setDefaultOptions)
+        * [.toJSON(resource, [options])](#module_concerto-core.Serializer+toJSON) ⇒ <code>Object</code>
+        * [.fromJSON(jsonObject, options)](#module_concerto-core.Serializer+fromJSON) ⇒ <code>Resource</code>
+    * _static_
+        * [.Symbol.hasInstance(object)](#module_concerto-core.Serializer.Symbol.hasInstance) ⇒ <code>boolean</code>
+
+<a name="new_module_concerto-core.Serializer_new"></a>
+
+#### new Serializer(factory, modelManager)
+Create a Serializer.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| factory | <code>Factory</code> | The Factory to use to create instances |
+| modelManager | <code>ModelManager</code> | The ModelManager to use for validation etc. |
+
+<a name="module_concerto-core.Serializer+setDefaultOptions"></a>
+
+#### serializer.setDefaultOptions(newDefaultOptions)
+Set the default options for the serializer.
+
+**Kind**: instance method of [<code>Serializer</code>](#module_concerto-core.Serializer)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| newDefaultOptions | <code>Object</code> | The new default options for the serializer. |
+
+<a name="module_concerto-core.Serializer+toJSON"></a>
+
+#### serializer.toJSON(resource, [options]) ⇒ <code>Object</code>
+<p>
+Convert a [Resource](Resource) to a JavaScript object suitable for long-term
+peristent storage.
+</p>
+
+**Kind**: instance method of [<code>Serializer</code>](#module_concerto-core.Serializer)  
+**Returns**: <code>Object</code> - - The Javascript Object that represents the resource  
+**Throws**:
+
+- <code>Error</code> - throws an exception if resource is not an instance of
+Resource or fails validation.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| resource | <code>Resource</code> | The instance to convert to JSON |
+| [options] | <code>Object</code> | the optional serialization options. |
+| [options.validate] | <code>boolean</code> | validate the structure of the Resource with its model prior to serialization (default to true) |
+| [options.convertResourcesToRelationships] | <code>boolean</code> | Convert resources that are specified for relationship fields into relationships, false by default. |
+| [options.permitResourcesForRelationships] | <code>boolean</code> | Permit resources in the place of relationships (serializing them as resources), false by default. |
+| [options.deduplicateResources] | <code>boolean</code> | Generate $id for resources and if a resources appears multiple times in the object graph only the first instance is serialized in full, subsequent instances are replaced with a reference to the $id |
+| [options.convertResourcesToId] | <code>boolean</code> | Convert resources that are specified for relationship fields into their id, false by default. |
+
+<a name="module_concerto-core.Serializer+fromJSON"></a>
+
+#### serializer.fromJSON(jsonObject, options) ⇒ <code>Resource</code>
+Create a [Resource](Resource) from a JavaScript Object representation.
+The JavaScript Object should have been created by calling the
+[toJSON](Serializer#toJSON) API.
+
+The Resource is populated based on the JavaScript object.
+
+**Kind**: instance method of [<code>Serializer</code>](#module_concerto-core.Serializer)  
+**Returns**: <code>Resource</code> - The new populated resource  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| jsonObject | <code>Object</code> | The JavaScript Object for a Resource |
+| options | <code>Object</code> | the optional serialization options |
+| options.acceptResourcesForRelationships | <code>boolean</code> | handle JSON objects in the place of strings for relationships, defaults to false. |
+| options.validate | <code>boolean</code> | validate the structure of the Resource with its model prior to serialization (default to true) |
+
+<a name="module_concerto-core.Serializer.Symbol.hasInstance"></a>
+
+#### Serializer.Symbol.hasInstance(object) ⇒ <code>boolean</code>
+Alternative instanceof that is reliable across different module instances
+
+**Kind**: static method of [<code>Serializer</code>](#module_concerto-core.Serializer)  
+**Returns**: <code>boolean</code> - - True, if the object is an instance of a Serializer  
+**See**: https://github.com/hyperledger/composer-concerto/issues/47  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| object | <code>object</code> | The object to test against |
 
 <a name="module_concerto-core.AssetDeclaration"></a>
 


### PR DESCRIPTION
### Changes
- A bad glob expression in the script that builds the API docs from the source code meant that some files were not shown

Notably, the `Serializer` class was missing from the Concerto API reference