### PR TITLE
fix(cicero-cli): Rename subcommand for consistency with the CLI

### DIFF
--- a/docs/cicero-cli.md
+++ b/docs/cicero-cli.md
@@ -172,7 +172,7 @@ Options:
 
 ## cicero compile
 
-`cicero generate` generates code for a target platform. It loads a template from a directory on disk and then attempts to generate versions of the template model in the specified format. The available formats include: `Go`, `PlantUML`, `Typescript`, `Java`, and `JSONSchema`.
+`cicero compile` generates code for a target platform. It loads a template from a directory on disk and then attempts to generate versions of the template model in the specified format. The available formats include: `Go`, `PlantUML`, `Typescript`, `Java`, and `JSONSchema`.
 
 ```md
 cicero compile


### PR DESCRIPTION
The changes introduced rename the subcommand `generate` as it longer exists. I think it has been replaced with `compile`.

### Changes
- Renamed `generate` to `compile`.

### Flags
- Please verify if my information about the typographical error is correct.
