### PR TITLE
docs(*): update cicero-ui docs to be in line with web-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,27 +191,14 @@ Accord Project is an open source, non-profit, initiative working to transform co
   <tr>
     <th  headers="blank">Projects</th>
     <th  headers="blank">Package name</th>
-    <th  headers="blank">Version</th>
     <th  headers="blank">Description</th>
   </tr>
-    <tr>
-      <td headers>Markdown Editor</td>
-      <td headers><a href="https://github.com/accordproject/markdown-editor">markdown-editor</a></td>
-      <td headers><a href="https://badge.fury.io/js/%40accordproject%2Fmarkdown-editor"><img src="https://badge.fury.io/js/%40accordproject%2Fmarkdown-editor.svg" alt="npm version"></a></td>
-      <td headers>WYSIWYG rich text web editor for markdown based on Slate.js</td>
-    </tr>
      <tr>
-     <td headers="co1 c1">Cicero UI</td>
-      <td headers="co2 c1"><a href="https://github.com/accordproject/cicero-ui">cicero-ui</a></td>
-      <td headers="co3 c1"> <a href="https://badge.fury.io/js/%40accordproject%2Fcicero-ui"><img src="https://badge.fury.io/js/%40accordproject%2Fcicero-ui.svg" alt="npm version"></a></td>
-       <td headers="co4 c1">React UI components for Cicero</td>
+     <td headers="co1 c1">Web Components</td>
+      <td headers="co2 c1"><a href="https://github.com/accordproject/web-components">web-components</a></td>
+      <td headers="co4 c1">React UI components including Markdown Editor, Contract Editor, Concerto Form and others</td>
      </tr>
      <tr>
-     <td headers="co1 c1">Concerto UI</td>
-      <td headers="co2 c1"><a href="https://github.com/accordproject/concerto-ui">concerto-ui</a></td>
-      <td headers="co3 c1"> <a href="https://badge.fury.io/js/%40accordproject%2Fconcerto-ui-react"><img src="https://badge.fury.io/js/%40accordproject%2Fconcerto-ui-react.svg" alt="npm version"></a></td>
-       <td headers="co4 c1">Dynamic web forms generated from Concerto models</td>
-     </tr>
 </table>
 
 #### Template Editors:

--- a/docs/ref-web-components.md
+++ b/docs/ref-web-components.md
@@ -1,13 +1,11 @@
 ---
-id: ref-cicero-ui
-title: Cicero UI Reference
+id: ref-web-components
+title: Web Components Reference
 ---
 
-Accord Project publishes [React](https://reactjs.org) user interface components for use in web-applications. Please refer to the cicero-ui project [on GitHub](https://github.com/accordproject/cicero-ui) for detailed usage instructions.
+Accord Project publishes [React](https://reactjs.org) user interface components for use in web applications. Please refer to the web-components project [on GitHub](https://github.com/accordproject/web-components) for detailed usage instructions.
 
-You can preview these components in [Template Studio v2](https://accordproject-studio.netlify.com).
-
-![Template-Studio-V2](/docs/assets/reference/tsv2.png)
+You can preview these components in [the project's storybook](https://ap-web-components.netlify.app/).
 
 ## Contract Editor
 
@@ -30,6 +28,6 @@ The Error Logger component is used to display structured error messages from the
 
 The Navigation component displays an outline view for a contract, allowing the user to quickly navigate between sections.
 
-## Template Library
+## Library
 
-The Template Library component displays a vertical list of template metadata, and allows the user to add a clause (instance of a template) to a contract.
+The Library component displays a vertical list of library item metadata, and allows the user to add an instance of a library item to a contract.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -17,30 +17,6 @@
       "accordproject": {
         "title": "Overview"
       },
-      "assets/architecture/node_modules/@types/node/README": {
-        "title": "assets/architecture/node_modules/@types/node/README"
-      },
-      "assets/architecture/node_modules/node/node_modules/node-darwin-x64/CHANGELOG": {
-        "title": "assets/architecture/node_modules/node/node_modules/node-darwin-x64/CHANGELOG"
-      },
-      "assets/architecture/node_modules/node/node_modules/node-darwin-x64/README": {
-        "title": "assets/architecture/node_modules/node/node_modules/node-darwin-x64/README"
-      },
-      "assets/architecture/node_modules/node/README": {
-        "title": "assets/architecture/node_modules/node/README"
-      },
-      "assets/architecture/node_modules/typescript/AUTHORS": {
-        "title": "assets/architecture/node_modules/typescript/AUTHORS"
-      },
-      "assets/architecture/node_modules/typescript/CONTRIBUTING": {
-        "title": "assets/architecture/node_modules/typescript/CONTRIBUTING"
-      },
-      "assets/architecture/node_modules/typescript/lib/README": {
-        "title": "assets/architecture/node_modules/typescript/lib/README"
-      },
-      "assets/architecture/node_modules/typescript/README": {
-        "title": "assets/architecture/node_modules/typescript/README"
-      },
       "cicero-api": {
         "title": "Cicero API"
       },
@@ -134,9 +110,6 @@
       "model-relationships": {
         "title": "Relationships"
       },
-      "ref-cicero-ui": {
-        "title": "Cicero UI Reference"
-      },
       "ref-errors": {
         "title": "Errors Reference"
       },
@@ -157,6 +130,9 @@
       },
       "ref-testing": {
         "title": "Testing Reference"
+      },
+      "ref-web-components": {
+        "title": "Web Components Reference"
       },
       "started-hello": {
         "title": "Hello World Template"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -40,7 +40,7 @@
         ],
         "Reference Manual": [
 	        "ref-glossary",
-            "ref-cicero-ui",
+            "ref-web-components",
             "ref-testing",
             "ref-errors",
             "ref-logic",


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

# Issue #292
<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- docs(*): update cicero-ui docs to be in line with web-components

### Flags
- This updates the `next` version of the docs. Not sure how the `0.20` version gets generated or if I'm supposed to manually change those versioned files?

