### PR TITLE
tag(0.21) Move decorators under concerto ref + republish 0.21

### DIFF
--- a/docs/ref-concerto-decorators.md
+++ b/docs/ref-concerto-decorators.md
@@ -1,0 +1,92 @@
+---
+id: ref-concerto-decorators
+title: Decorators
+---
+
+Decorators are used to add metadata to Concerto model elements, typically to control how variables are edited, printed or transformed.
+
+## Pdf
+
+The `@Pdf` decorator is used to control how a variable is rendered by the `markdown-pdf` transformation, which is used to convert CiceroMark rich text to PDF.
+
+### Attributes
+
+**style** : specifies the style name used to render the variable. Default styles are [defined in the code](https://github.com/accordproject/markdown-transform/blob/master/packages/markdown-pdf/src/PdfTransformer.js#L278) and may be overridden or supplemented via the `options.styles` parameter.
+
+### Example
+
+The example below renders the `title` variable using the PDF background style, which is defined to have the color `white`.
+
+```
+asset ExampleClause extends AccordClause {
+   @Pdf("style", "background")
+   o String title
+}
+```
+
+## ContractEditor
+
+The `@ContractEditor` decorator is used to control how a variable is edited using the `ContractEditor` React [web-components](https://github.com/accordproject/web-components).
+
+### Attributes
+
+**readOnly** : when set to true the variable value cannot be edited
+
+**fontFamily** : the name of the HTML font-family to use when rendering the variable
+
+**backgroundColor** : the HTML background color to use when rendering the variable
+
+**border** : the HTML border color to use when rendering the variable
+
+### Example
+
+The example below renders the `title` variable using custom font, background color and border color. The variable is read-only and cannot be edited.
+
+```
+asset ExampleClause extends AccordClause {
+   @ContractEditor("readOnly", true, 
+    "fontFamily", "Lucida Console, Courier, monospace",
+    "backgroundColor", "#FAE094", "border", '#CCA855' )
+   o String title
+}
+```
+
+## FormEditor
+
+The `@FormEditor` decorator is used to control whether the `ConcertoForm` React [web-components](https://github.com/accordproject/web-components) creates an input field for the variable.
+
+### Attributes
+
+**hide** : when set to true an input field for the variable is not created
+
+### Example
+
+The example specifies that an input field for the `title` variable should not be created by the Concerto Form component. 
+
+```
+asset ExampleClause extends AccordClause {
+   @FormEditor("hide", true)
+   o String title
+}
+```
+
+## DocuSignTab
+
+The `@DocuSignTab` decorator is used to specify how a variable is mapped to a DocuSign tab. This decorator is not currently supported by existing Accord Project transformations but is reserved for future use, and may be used by upstream consumers.
+
+### Attributes
+
+**type** : the type of the DocuSign tab. See the documentation for DocuSign [EnvelopeRecipientTabs](https://developers.docusign.com/docs/esign-rest-api/reference/Envelopes/EnvelopeRecipientTabs/#tab-types) for the list of supported tab types.
+
+**optional** : whether the tab is optional or required
+
+### Example
+
+The example below maps the `title` variable to the DocuSign tab type `Title` and marks it as optional.
+
+```
+asset ExampleClause extends AccordClause {
+  @DocuSignTab("type", "Title", "optional", true)
+   o String title
+}
+```

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -101,7 +101,7 @@
       "ref-concerto-cli": {
         "title": "Command Line"
       },
-      "ref-decorators": {
+      "ref-concerto-decorators": {
         "title": "Decorators"
       },
       "ref-ergo-api": {
@@ -512,6 +512,9 @@
       "version-0.21/version-0.21-model-classes": {
         "title": "Classes"
       },
+      "version-0.21/version-0.21-model-decorators": {
+        "title": "Decorators"
+      },
       "version-0.21/version-0.21-model-properties": {
         "title": "Properties"
       },
@@ -532,6 +535,9 @@
       },
       "version-0.21/version-0.21-ref-concerto-cli": {
         "title": "Command Line"
+      },
+      "version-0.21/version-0.21-ref-concerto-decorators": {
+        "title": "Decorators"
       },
       "version-0.21/version-0.21-ref-ergo-api": {
         "title": "Node.js API"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -50,7 +50,7 @@
             {
                 "type": "subcategory",
                 "label": "Cicero Reference",
-                "ids": ["ref-decorators", "ref-cicero-cli", "ref-cicero-api", "ref-cicero-testing"]
+                "ids": ["ref-cicero-cli", "ref-cicero-api", "ref-cicero-testing"]
             },
             {
                 "type": "subcategory",
@@ -60,7 +60,7 @@
             {
                 "type": "subcategory",
                 "label": "Concerto Reference",
-                "ids": ["ref-concerto-cli", "ref-concerto-api"]
+                "ids": ["ref-concerto-decorators", "ref-concerto-cli", "ref-concerto-api"]
             },
             {
                 "type": "subcategory",

--- a/website/versioned_docs/version-0.21/model-decorators.md
+++ b/website/versioned_docs/version-0.21/model-decorators.md
@@ -1,0 +1,30 @@
+---
+id: version-0.21-model-decorators
+title: Decorators
+original_id: model-decorators
+---
+
+Model elements may have arbitrary decorators (aka annotations) placed on them. These are available via API and can be useful for tools to extend the model. Accord Project decorators are defined in the [Decorators Reference](ref-decorators).
+
+```js
+@foo("arg1", 2)
+asset Order identified by orderId {
+  o String orderId
+}
+```
+
+Decorators have an arbitrary number of arguments. They support arguments of type:
+- String
+- Boolean
+- Number
+- Type reference
+
+Resource definitions and properties may be decorated with 0 or more decorations. Note that only a single instance of a decorator is allowed on each element type. I.e. it is invalid to have the @bar decorator listed twice on the same element.
+
+Decorators are accessible at runtime via the `ModelManager` introspect APIs. This allows tools and utilities to use Concerto to describe a core model, while decorating it with sufficient metadata for their own purposes.
+
+The example below retrieves the 3rd argument to the foo decorator attached to the myField property of a class declaration:
+
+```js
+const val = myField.getDecorator('foo').getArguments()[2];
+```

--- a/website/versioned_docs/version-0.21/model-properties.md
+++ b/website/versioned_docs/version-0.21/model-properties.md
@@ -31,7 +31,21 @@ Concerto supports the following primitive types:
 
 `String` fields may include an optional regular expression, which is used to validate the contents of the field. Careful use of field validators allows Concerto to perform rich data validation, leading to fewer errors and less boilerplate application code.
 
-`Double`, `Long` or `Integer` fields may include an optional range expression, which is used to validate the contents of the field.
+The example below validates that a `String` variable starts with `abc`:
+
+```
+  o String myString regex=/abc.*/ 
+```
+
+`Double`, `Long` or `Integer` fields may include an optional range expression, which is used to validate the contents of the field. Both the lower and upper bound are optional, however at least one must be specified. The upper bound must be greater than or equal to the lower bound.
+
+```
+  o Integer intLowerUpper range=[-1,1] // greater than or equal to -1 and less than 1
+  o Integer intLower range=[-1,] // greater than or equal to -1
+  o Integer intUpper range=[,1] // less than 1
+```
+
+#### Example
 
 ```
 asset Vehicle {

--- a/website/versioned_docs/version-0.21/ref-concerto-decorators.md
+++ b/website/versioned_docs/version-0.21/ref-concerto-decorators.md
@@ -1,6 +1,7 @@
 ---
-id: ref-decorators
+id: version-0.21-ref-concerto-decorators
 title: Decorators
+original_id: ref-concerto-decorators
 ---
 
 Decorators are used to add metadata to Concerto model elements, typically to control how variables are edited, printed or transformed.

--- a/website/versioned_sidebars/version-0.21-sidebars.json
+++ b/website/versioned_sidebars/version-0.21-sidebars.json
@@ -116,6 +116,7 @@
         "type": "subcategory",
         "label": "Concerto Reference",
         "ids": [
+          "version-0.21-ref-concerto-decorators",
           "version-0.21-ref-concerto-cli",
           "version-0.21-ref-concerto-api"
         ]


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Move decorators documentation under concerto reference (rather than cicero reference)
- Retag/republish 0.21 version of the documentation
