### PR TITLE
fix(ergo) Add documentation for Ergo 'as' expression

### DIFF
--- a/website/versioned_docs/version-0.21/logic-advanced-expr.md
+++ b/website/versioned_docs/version-0.21/logic-advanced-expr.md
@@ -1,6 +1,7 @@
 ---
-id: logic-advanced-expr
+id: version-0.21-logic-advanced-expr
 title: Advanced Expressions
+original_id: logic-advanced-expr
 ---
 
 ## Match


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Fixes wrong link in Ergo "Template Literal" section
- Add new section for Ergo formatting using `as`

### Related Issues
- Issue https://github.com/accordproject/cicero/issues/599
