### PR TITLE
docs(*): clarify type restriction on identity fields

### DIFF
--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -42,6 +42,8 @@ concept Product identified {
 }
 ```
 
+When using `identified by`, the explicitly named identity field must be of type `String`. Identifying fields of other types are not supported.
+
 ## Assets
 
 An asset is a class declaration that has a single `String` property which acts as an identifier. You can use the `modelManager.getAssetDeclarations` API to look up all assets.


### PR DESCRIPTION
Concerto enforces at runtime that identifying fields must be of type `String`, but the documentation does not reflect this. This change updates the documentation to clarify the type restriction on identity fields.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>