### PR TITLE
docs(properties): clarify DateTime supported formats 

### DIFF
--- a/docs/model-properties.md
+++ b/docs/model-properties.md
@@ -15,8 +15,27 @@ Concerto supports the following primitive types:
 |`Double` | a double precision 64 bit numeric value.
 |`Integer` | a 32 bit signed whole number.
 |`Long` | a 64 bit signed whole number.
-|`DateTime` | an ISO-8601 compatible time instance, with optional time zone and UTZ offset.
+|`DateTime` | an ISO 8601 & RFC 3339 compatible date or dateTime instance, with UTC offset.
 |`Boolean` | a Boolean value, either true or false.
+
+:::note
+The most general form of supported `DateTime` values is `2022-11-28T12:10:05.105-05:00` however, other values are supported. During validation, `DateTime` values will be normalized to this format.
+
+We guarantee to support values that are included in the ISO 8601-1:2019, RFC 3339 and HTML Living Standard specifications. Other formats may be accepted depending on your platforms, but are subject to change.
+
+Supported date & dateTime formats foe the `DateTime` primitive type:
+- `YYYY-MM-DD`
+- `YYYY-MM-DDTHH:mm:ssZ`
+- `YYYY-MM-DDTHH:mm:ss.SZ`
+- `YYYY-MM-DDTHH:mm:ss.SSZ`
+- `YYYY-MM-DDTHH:mm:ss.SSSZ`
+- `YYYY-MM-DDTHH:mm:ss.S±HH:mm`
+- `YYYY-MM-DDTHH:mm:ss.SS±HH:mm`
+- `YYYY-MM-DDTHH:mm:ss.SSS±HH:mm`
+
+Milliseconds will be truncated at 3 digits.
+:::
+
 
 ### Meta Properties
 

--- a/docs/model-properties.md
+++ b/docs/model-properties.md
@@ -19,13 +19,10 @@ Concerto supports the following primitive types:
 |`Boolean` | a Boolean value, either true or false.
 
 :::note
-The most general form of supported `DateTime` values is `2022-11-28T12:10:05.105-05:00` however, other values are supported. During validation, `DateTime` values will be normalized to this format.
-
-We guarantee to support values that are included in the ISO 8601-1:2019, RFC 3339 and HTML Living Standard specifications. Other formats may be accepted depending on your platforms, but are subject to change.
-
-Supported date & dateTime formats foe the `DateTime` primitive type:
+Supported date & date-time formats for the `DateTime` primitive type:
 - `YYYY-MM-DD`
 - `YYYY-MM-DDTHH:mm:ssZ`
+- `YYYY-MM-DDTHH:mm:ss±HH:mm`
 - `YYYY-MM-DDTHH:mm:ss.SZ`
 - `YYYY-MM-DDTHH:mm:ss.SSZ`
 - `YYYY-MM-DDTHH:mm:ss.SSSZ`
@@ -34,6 +31,8 @@ Supported date & dateTime formats foe the `DateTime` primitive type:
 - `YYYY-MM-DDTHH:mm:ss.SSS±HH:mm`
 
 Milliseconds will be truncated at 3 digits.
+
+We guarantee to support values that are included by the ISO 8601-1:2019, RFC 3339 and HTML Living Standard specifications. However, other formats may be accepted depending on your platforms, but are subject to change. During validation, `DateTime` values will be normalized to the `YYYY-MM-DDTHH:mm:ss.SSSZ` format. 
 :::
 
 

--- a/website/versioned_docs/version-0.23.0/model-properties.md
+++ b/website/versioned_docs/version-0.23.0/model-properties.md
@@ -16,8 +16,26 @@ Concerto supports the following primitive types:
 |`Double` | a double precision 64 bit numeric value.
 |`Integer` | a 32 bit signed whole number.
 |`Long` | a 64 bit signed whole number.
-|`DateTime` | an ISO-8601 compatible time instance, with optional time zone and UTZ offset.
+|`DateTime` | an ISO 8601 & RFC 3339 compatible date or dateTime instance, with UTC offset.
 |`Boolean` | a Boolean value, either true or false.
+
+:::note
+Supported date & date-time formats for the `DateTime` primitive type:
+- `YYYY-MM-DD`
+- `YYYY-MM-DDTHH:mm:ssZ`
+- `YYYY-MM-DDTHH:mm:ss±HH:mm`
+- `YYYY-MM-DDTHH:mm:ss.SZ`
+- `YYYY-MM-DDTHH:mm:ss.SSZ`
+- `YYYY-MM-DDTHH:mm:ss.SSSZ`
+- `YYYY-MM-DDTHH:mm:ss.S±HH:mm`
+- `YYYY-MM-DDTHH:mm:ss.SS±HH:mm`
+- `YYYY-MM-DDTHH:mm:ss.SSS±HH:mm`
+
+Milliseconds will be truncated at 3 digits.
+
+We guarantee to support values that are included by the ISO 8601-1:2019, RFC 3339 and HTML Living Standard specifications. However, other formats may be accepted depending on your platforms, but are subject to change. During validation, `DateTime` values will be normalized to the `YYYY-MM-DDTHH:mm:ss.SSSZ` format. 
+:::
+
 
 ### Meta Properties
 


### PR DESCRIPTION
We do not support the full ISO 8601 standard for `DateTime` values as advertised. We also support other formats that are not in ISO 8601.
 
Concerto in fact supports date and date-time formats that are in the intersection of the following specifications:
- ISO 8601
- RFC 3339
- HTML Living Standard.

See https://ijmacd.github.io/rfc3339-iso8601/ for a visualisation of the intersection.

Other formats outside of this intersection happen to be supported by DayJS. This behaviour is retained for backwards compatibility but is subject to change in future. Other platforms (such as .NET) should only commit to supporting the same subset as specified here.

Based on the recently extended test suite for JSON population (used in validation). This PR extends the documentation to be more specific about the date and date-time formats that Concerto supports.

Tests reference:
https://github.com/accordproject/concerto/blob/main/packages/concerto-core/test/serializer.js#L420-L468

