### PR TITLE
doc(docs): fix some typos

### DIFF
--- a/docs/accordproject-faq.md
+++ b/docs/accordproject-faq.md
@@ -17,7 +17,7 @@ While the Accord Project technology is targeted at the development of smart lega
 
 ### How is an Accord Project "Smart Contract" different from "Smart Contracts" on the blockchain?
 
-Accord Project Smart legal contracts should not be confused with so-called blockchain “smart contracts”, which are scripts that necesarily operate on a blockchain. On the blockchain a smart contract is often written in a specific language like solidity that executes and operates on the blockchain. It lives in a closed world. An Accord Project Smart Contract contains text based template that integrates with a data model and the Ergo language. The three components are integrated into a whole. Using Ergo an Accord Project Smart contract can communicate with other systems, it can send and receive data, it can perform calculations and it can interact with a blockchain.
+Accord Project Smart legal contracts should not be confused with so-called blockchain “smart contracts”, which are scripts that necessarily operate on a blockchain. On the blockchain a smart contract is often written in a specific language like solidity that executes and operates on the blockchain. It lives in a closed world. An Accord Project Smart Contract contains text based template that integrates with a data model and the Ergo language. The three components are integrated into a whole. Using Ergo an Accord Project Smart contract can communicate with other systems, it can send and receive data, it can perform calculations and it can interact with a blockchain.
 
 ### What benefits do Smart Legal Contracts provide?
 

--- a/docs/accordproject-tour.md
+++ b/docs/accordproject-tour.md
@@ -15,7 +15,7 @@ The following video offers a tour of Template Studio and an introduction to the 
 
 Here is a timestamp of what is covered in the video:
 
-- **00:08** : Introduction to template Studio & pointing to the other parts of the docs / AP website
+- **00:08** : Introduction to template Studio & pointers the other parts of the docs / AP website
 - **03:51** : Helloworld template tutorial start
 - **04:48** : Template Studio - Metadata
 - **06:56** : Template Studio - Contract Text

--- a/docs/accordproject-tour.md
+++ b/docs/accordproject-tour.md
@@ -3,7 +3,7 @@ id: accordproject-tour
 title: Online Tour
 ---
 
-To get an better acquainted with Accord Project templates, the easiest way is through the online [Template Studio](https://studio.accordproject.org) editor.
+To get better acquainted with Accord Project templates, the easiest way is through the online [Template Studio](https://studio.accordproject.org) editor.
 
 :::tip
 You can open template studio from anywhere in this documentation by clicking the [Try Online!](https://studio.accordproject.org) button located in the top-right of the page.
@@ -15,7 +15,7 @@ The following video offers a tour of Template Studio and an introduction to the 
 
 Here is a timestamp of what is covered in the video:
 
-- **00:08** : Introduction to template Studio & pointers the other parts of the docs / AP website
+- **00:08** : Introduction to template Studio & pointing to the other parts of the docs / AP website
 - **03:51** : Helloworld template tutorial start
 - **04:48** : Template Studio - Metadata
 - **06:56** : Template Studio - Contract Text

--- a/docs/accordproject.md
+++ b/docs/accordproject.md
@@ -18,7 +18,7 @@ The Accord Project provides a universal format for smart legal contracts, and th
 Contracting is undergoing a digital transformation driven by a need to deliver customer-centric legal and business solutions faster, and at lower cost. This imperative is fueling the adoption of a broad range of new technologies to improve the efficiency of drafting, managing, and executing legal contracting operations; the Accord Project is proud to be part of that movement.
 
 The Accord Project provides a Smart Contract that does not depend on a blockchain, that can integrate text
-and data and that can continue operating over its lifespan. The Accord Project smart contract can integrate with your technology platforms and become part of you digital infrastructure.
+and data and that can continue operating over its lifespan. The Accord Project smart contract can integrate with your technology platforms and become part of your digital infrastructure.
 
 In addition, contributions from businesses are crucial for the development of the Accord Project. The expertise of stakeholders, such as business professionals and attorneys, is invaluable in improving the functionality and content of the Accord Project's codebase and specifications, to ensure that the templates meet real-world business requirements.
 

--- a/docs/ergo-tutorial.md
+++ b/docs/ergo-tutorial.md
@@ -18,7 +18,7 @@ DAYS and MESSAGE are variables
  
 You can browse the library of Open Source Cicero contract and clause templates at: https://templates.accordproject.org.
 
-So how goes the contract get executed? That is where Ergo comes in Ergo is a strongly-typed functional programming language designed to capture the legal intent of legal contracts and clauses. We will use Ergo to create the contract logic consisting of a contract class with executable embedded clauses. Note: prior to the emergence of Ergo, the Cicero JavaScript component was primary to the execution of code.
+So how does the contract get executed? That is where Ergo comes in. Ergo is a strongly-typed functional programming language designed to capture the legal intent of legal contracts and clauses. We will use Ergo to create the contract logic consisting of a contract class with executable embedded clauses. Note: prior to the emergence of Ergo, the Cicero JavaScript component was primary to the execution of code.
 
 Ergo obviates the Cicero JavaScript component for the execution phase with a new more comprehensive language which we explore in this tutorial.
    
@@ -58,7 +58,7 @@ See, https://code.visualstudio.com/docs/setup/
 * Linux
 * Windows
 
-#### Install Ergo VisualStudio Plugin
+#### Install Ergo Visual Studio Plugin
    
 ### Validate Development Environment and Toolset
 

--- a/docs/example-eatapple.md
+++ b/docs/example-eatapple.md
@@ -11,7 +11,7 @@ For this example, let us look first at the template for that legal clause writte
 
 ```markdown
 Eating healthy clause between [{employee}] (the Employee) and [{company}] (the Company).
-The canteen only sells apple products. Apples, apple juice, apple flapjacks, toffee
+The canteen only sells apple products. Apples, apple juice, apple flapjacks, and toffee
 apples. Employee gets fired if caught eating anything without apples in it.
 THE EMPLOYEE, IF ALLERGIC TO APPLES, SHALL ALWAYS BE HUNGRY.
 Apple products at the canteen are subject to a [{tax}]% tax.

--- a/docs/logic-advanced-expr.md
+++ b/docs/logic-advanced-expr.md
@@ -47,7 +47,7 @@ Should return the array `["Product (Blender)", "Car (Batmobile) with range Infin
 
 ## Foreach
 
-Foreach expressions allow to apply an expression of every element in
+Foreach expressions allow to apply an expression on every element in
 an input array of values and returns a new array:
 
 ```ergo
@@ -61,7 +61,7 @@ iterated over:
   foreach x in [1.0,-2.0,3.0] where x > 0.0 return x + 1.0
 ```
 
-Foreach expressions can iterate over multiple arrays. For example, the following foreach expression returns all all [Pythagorean triples](https://en.wikipedia.org/wiki/Pythagorean_triple):
+Foreach expressions can iterate over multiple arrays. For example, the following foreach expression returns all [Pythagorean triples](https://en.wikipedia.org/wiki/Pythagorean_triple):
 ```ergo
 let nums = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
 foreach x in nums


### PR DESCRIPTION
### Changes
- Fixed typos in docs directory 
### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
