### PR TITLE
Afadnan/454/fix white space scroll

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "website",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.21.2",

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -6,6 +6,17 @@
  */
 
 /* Reset */
+html, body {
+  height: 100%;
+  width:100%;
+  margin: 0;
+  padding: 0;
+  overflow-y:auto;
+  overflow-x:hidden;
+  overscroll-behavior: contain;
+}
+
+
 html,
 body,
 div,


### PR DESCRIPTION
# Bug Fix: Prevent White Space on Header/Footer Scroll

## Closes

- Closes https://github.com/accordproject/techdocs/issues/454

## Summary
This PR fixes an issue where scrolling beyond the top or bottom of the webpage caused unwanted white space to appear at the header and footer.

## Changes
Applied CSS fix to prevent excessive scrolling.

Ensured html, body height is properly set to 100%.

Removed unwanted overflow behavior.

## Steps to Reproduce (Before Fix)
Open the website.
Scroll up beyond the top of the page.
Scroll down to the bottom and continue scrolling.
Notice the white space appearing above the header or below the footer.

## Expected Behavior
Scrolling should naturally stop at the top and bottom of the page without revealing extra white space.

## Fix Implementation
✅ Applied CSS to fix:
✅ Mention Video Below :

# 📌 Before (Bug Video) :

https://github.com/user-attachments/assets/9c701d63-1910-4889-9fe0-5c4b6a530a5b

# 📌 After (Fixed Video): 


https://github.com/user-attachments/assets/acf2ba04-a6c4-4758-bf2b-cbb0ff17f768



## Related Issues
Issue https://github.com/accordproject/techdocs/issues/454 – [Bug] Scrolling Beyond Limits Causes White Space at Header/Footer

## Author Checklist
✅ Ensured commit message follows [AP format](https://github.com/accordproject/techdocs/blob/main/DEVELOPERS.md#commit-message-format)
✅ Provided a [DCO sign-off](https://github.com/probot/dco#how-it-works) using git commit -s
✅ Linked to related issue https://github.com/accordproject/techdocs/issues/454 in the PR description

