### PR TITLE
fix: update communication channels from Slack to Discord in documenta…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "techdocs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/website/versioned_docs/version-0.12/accordproject-resources.md
+++ b/website/versioned_docs/version-0.12/accordproject-resources.md
@@ -9,17 +9,17 @@ original_id: accordproject-resources
 - The Main Web site includes latest news, links to working groups, organizational announcements, etc. : https://www.accordproject.org
 - This Technical Documentation: https://docs.accordproject.org
 - Recording of Working Group discussions, Tutorial Videos are on available on Vimeo: https://vimeo.com/accordproject
-- Accord Project's [Slack](https://accord-project.slack.com/)
+- Accord Project's [Discord](https://discord.com/invite/Zm99SKhhtA)
 
 ## Cicero Resources
 
 - GitHub: https://github.com/accordproject/cicero
-- Slack [Channel](https://accord-project.slack.com/messages/CA08NAHQS/details/)
+- Discord [Channel](https://discord.gg/Zm99SKhhtA)
 - Technical Questions and Answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/cicero)
 
 ## Ergo Resources
 
 - GitHub: https://github.com/accordproject/ergo
 - The [Ergo Language Guide](logic-ergo) is a good place to get started with Ergo.
-- Slack [Channel](https://accord-project.slack.com/messages/C9HLJHREG/details/)
+- Discord [Channel](https://discord.gg/Zm99SKhhtA)
 

--- a/website/versioned_docs/version-0.12/accordproject-tooling.md
+++ b/website/versioned_docs/version-0.12/accordproject-tooling.md
@@ -27,7 +27,7 @@ A simple Emacs mode for Ergo can be found in the [ergo-mode](https://github.com/
 
 A simple VIM mode for Ergo can be found in the [ergo.vim](https://github.com/accordproject/ergo/tree/master/ergo.vim) directory in the Ergo source code on GitHub.
 
-> Those are not maintained as actively as the rest of the Accord Project. If you know emacs lisp or are a VIM user and would like to contribute, please contact us on the Accord Project Slack or directly through GitHub!
+> Those are not maintained as actively as the rest of the Accord Project. If you know emacs lisp or are a VIM user and would like to contribute, please contact us on the Accord Project Discord or directly through GitHub!
 
 ## Template Studio
 

--- a/website/versioned_docs/version-0.12/accordproject.md
+++ b/website/versioned_docs/version-0.12/accordproject.md
@@ -74,7 +74,7 @@ Several tools are also available to facilitate authoring of Accord Project templ
 
 The Accord Project technology is being developed as open source. All the software packages are being actively maintained on [GitHub](https://github.com/accordproject) and we encourage organizations and individuals to contribute requirements, documentation, issues, new templates, and code.
 
-Join the Accord Project Technology Working Group <a href="https://docs.google.com/forms/d/e/1FAIpQLScmPLO6vflTKFTRTJXiopCjGEvS5mMeH-ZlBnuStiQ3U4k19A/viewform">Slack channel</a> to get involved!
+Join the Accord Project Technology Working Group <a href="https://discord.gg/Zm99SKhhtA">Discord channel</a> to get involved!
 
 ## Try Accord Project Online
 

--- a/website/versioned_docs/version-0.20/accordproject-business.md
+++ b/website/versioned_docs/version-0.20/accordproject-business.md
@@ -27,6 +27,6 @@ If your organization wants to become a member of the Accord Project, please [joi
 
 If you are new to the Accord Project, the best place to start is our [Online Tour](started-studio). This video is a great way to see the Accord Project in action! If you want to read more about the key concepts behind the Accord Project technology (or learn more about the template model), please read the [Key Concepts](accordproject-concepts) page. This will allow you to understand the three components of a template (text, model, and logic) and how they work together.
 
-If any of the technical terms are confusing or hard to understand, we have a [Glossary](ref-glossary) page that may help you. If there are any concepts or terms that you want to include in the Glossary, please join our [slack channel](https://accord-project-slack-signup.herokuapp.com/) and make suggestions!
+If any of the technical terms are confusing or hard to understand, we have a [Glossary](ref-glossary) page that may help you. If there are any concepts or terms that you want to include in the Glossary, please join our [Discord channel](https://discord.gg/Zm99SKhhtA) and make suggestions!
 
 If you want to create a template yourself, please see [Authoring in Template Studio](tutorial-latedelivery) for a step-by-step guide on how to create your first template. The tutorial will provide an accessible starting point for those without significant development experience to begin building smart legal contracts using the Accord Project technology.

--- a/website/versioned_docs/version-0.20/accordproject-developers.md
+++ b/website/versioned_docs/version-0.20/accordproject-developers.md
@@ -10,7 +10,7 @@ The Accord Project provides a universal format for smart legal contracts, and th
 
 Developers can contribute by converting legal text into corresponding computer code, creating Accord Project templates to be used by lawyers and businesses. In addition, developers can provide input on the development of its technology stack: language, models, templating, and other tools.
 
-If this interests you, please visit our [Technology Working Group](https://www.accordproject.org/working-groups/technology) page, and join our [slack channel](https://accord-project-slack-signup.herokuapp.com/)!
+If this interests you, please visit our [Technology Working Group](https://www.accordproject.org/working-groups/technology) page, and join our [Discord channel](https://discord.gg/Zm99SKhhtA)!
 
 ## How to navigate this documentation?
 

--- a/website/versioned_docs/version-0.20/started-resources.md
+++ b/website/versioned_docs/version-0.20/started-resources.md
@@ -9,7 +9,7 @@ original_id: started-resources
 - The Main Web site includes latest news, links to working groups, organizational announcements, etc. : https://www.accordproject.org
 - This Technical Documentation: https://docs.accordproject.org
 - Recording of Working Group discussions, Tutorial Videos are available on Vimeo: https://vimeo.com/accordproject
-- Join the [Accord Project Slack](https://accord-project-slack-signup.herokuapp.com) to get involved!
+- Join the [Accord Project Discord](https://discord.gg/Zm99SKhhtA) to get involved!
 
 ## User Content
 
@@ -38,16 +38,16 @@ Accord Project is also developing tools to help with authoring, testing and runn
 
 All the Accord Project technology is being developed as open source. The software packages are being actively maintained on [GitHub](https://github.com/accordproject) and we encourage organizations and individuals to contribute requirements, documentation, issues, new templates, and code.
 
-Join us on the [#technology-wg Slack channel](https://accord-project-slack-signup.herokuapp.com) for technical discussions and weekly updates.
+Join us on the [#technology-wg Discord channel](https://discord.gg/Zm99SKhhtA) for technical discussions and weekly updates.
 
 ### Cicero
 
 - GitHub: https://github.com/accordproject/cicero
-- [Cicero Slack Channel](https://accord-project.slack.com/messages/CA08NAHQS/details/)
+- [Cicero Discord Channel](https://discord.com/invite/Zm99SKhhtA)
 - Technical Questions and Answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/cicero)
 
 ### Ergo
 
 - GitHub: https://github.com/accordproject/ergo
 - The [Ergo Language Guide](logic-ergo) is a good place to get started with Ergo.
-- [Ergo Slack Channel](https://accord-project.slack.com/messages/C9HLJHREG/details/)
+- [Ergo Discord Channel](https://discord.com/invite/Zm99SKhhtA)

--- a/website/versioned_docs/version-0.21/accordproject-faq.md
+++ b/website/versioned_docs/version-0.21/accordproject-faq.md
@@ -47,8 +47,7 @@ The purpose of the Accord Project is to establish and maintain a common and cons
 
 ### How can I get involved?
 
-The Accord Project Community is developing several working groups focusing on different applications of  smart contracts. The working groups have frequent calls and use the Accord Project’s Slack group chat application (join by clicking [here](https://accord-project-slack-signup.herokuapp.com/)) for discussion. The dates, dial-in instructions, and agendas for the working groups are all listed in the Project’s public calendar and typically also in working group’s respective slack channels.
-
+The Accord Project Community is developing several working groups focusing on different applications of  smart contracts. The working groups have frequent calls and use the Accord Project’s Discord group chat application (join by clicking [here](https://discord.gg/Zm99SKhhtA/)) for discussion. The dates, dial-in instructions, and agendas for the working groups are all listed in the Project’s public calendar and typically also in working group’s respective Discord channel
 A primary purpose of the working groups is to develop a universally accessible and widely used open source library of modular, smart legal contracts, smart templates and models that reflect input from the community. Smart legal contract templates are built according to the Project’s [Cicero Specification](https://github.com/accordproject/cicero).
 
 Members can provide feedback into the templates and models relevant to a particular working group. You can immediately start contributing smart legal contract templates and models by using the Accord Project’s [Template Studio](https://studio.accordproject.org/).

--- a/website/versioned_docs/version-0.21/accordproject.md
+++ b/website/versioned_docs/version-0.21/accordproject.md
@@ -41,7 +41,7 @@ The Accord Project provides a universal format for smart legal contracts, and th
 
 The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
 
-There is a welcoming community on Slack that is eager to help. [Join our Community](https://www.accordproject.org/membership/)
+There is a welcoming community on Discord that is eager to help. [Join our Community](https://discord.com/invite/Zm99SKhhtA)
 
 
 ## About this documentation

--- a/website/versioned_docs/version-0.21/started-resources.md
+++ b/website/versioned_docs/version-0.21/started-resources.md
@@ -9,7 +9,7 @@ original_id: started-resources
 - The Main Web site includes latest news, links to working groups, organizational announcements, etc. : https://www.accordproject.org
 - This Technical Documentation: https://docs.accordproject.org
 - Recording of Working Group discussions, Tutorial Videos are available on Vimeo: https://vimeo.com/accordproject
-- Join the [Accord Project Slack](https://accord-project-slack-signup.herokuapp.com) to get involved!
+- Join the [Accord Project Discord](https://discord.gg/Zm99SKhhtA) to get involved!
 
 ## User Content
 
@@ -38,16 +38,16 @@ Accord Project is also developing tools to help with authoring, testing and runn
 
 All the Accord Project technology is being developed as open source. The software packages are being actively maintained on [GitHub](https://github.com/accordproject) and we encourage organizations and individuals to contribute requirements, documentation, issues, new templates, and code.
 
-Join us on the [#technology-wg Slack channel](https://accord-project-slack-signup.herokuapp.com) for technical discussions and weekly updates.
+Join us on the [#technology-wg Discord channel](https://discord.gg/Zm99SKhhtA) for technical discussions and weekly updates.
 
 ### Cicero
 
 - GitHub: https://github.com/accordproject/cicero
-- [Cicero Slack Channel](https://accord-project.slack.com/messages/CA08NAHQS/details/)
+- [Cicero Discord Channel](https://discord.com/invite/Zm99SKhhtA)
 - Technical Questions and Answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/cicero)
 
 ### Ergo
 
 - GitHub: https://github.com/accordproject/ergo
 - The [Ergo Language Guide](logic-ergo) is a good place to get started with Ergo.
-- [Ergo Slack Channel](https://accord-project.slack.com/messages/C9HLJHREG/details/)
+- [Ergo Discord Channel](https://discord.com/invite/Zm99SKhhtA)


### PR DESCRIPTION
This PR updates the documentation to replace deprecated Slack references with the official Discord invite link.

It removes outdated Slack signup links and ensures community links point to Discord as requested in issue #388.