### PR TITLE
docs: update Cicero CLI version to 0.24.0 and fix note formatting

### DIFF
--- a/docs/started-installation.md
+++ b/docs/started-installation.md
@@ -21,13 +21,12 @@ To install the latest version of the Cicero command-line tools:
 npm install -g @accordproject/cicero-cli
 ```
 
-:::note
-You can install a specific version by appending `@version` at the end of the `npm install` command. For instance to install version `0.20.3` or version `0.13.4`:
-```bash
-npm install -g @accordproject/cicero-cli@0.20.3
-npm install -g @accordproject/cicero-cli@0.13.4
-```
-:::
+> You can install a specific version by appending `@version` at the end of the `npm install` command. For instance to install version `0.24.0` or version `0.13.4`:
+>
+> ```bash
+> npm install -g @accordproject/cicero-cli@0.24.0
+> npm install -g @accordproject/cicero-cli@0.13.4
+> ```
 
 To check that Cicero has been properly installed, and display the version number:
 ```bash


### PR DESCRIPTION
### Closes N/A
This pull request updates the documentation to reference the latest stable version of the Cicero CLI and improves the markdown formatting for better compatibility.

### Changes
- [docs/started-installation.md](cci:7://file:///c:/Users/Lenovo/techdocs/docs/started-installation.md:0:0-0:0): Updated outdated Cicero CLI version references from `0.20.3` to `0.24.0` in the installation commands to match the latest stable release.
- [docs/started-installation.md](cci:7://file:///c:/Users/Lenovo/techdocs/docs/started-installation.md:0:0-0:0): Replaced custom `:::note` admonition syntax with standard Markdown blockquotes (`>`) to ensure correct rendering.

### Flags
None

### Screenshots or Video
N/A (Documentation updates only)

### Related Issues
N/A

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the --signoff option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [x] Extend the documentation, if necessary
- [x] Merging to main from fork:docs/update-cicero-version