### PR TITLE
fix: correct Rental Deposit link target, fix bash comment syntax, and update outdated URLs

### DIFF
--- a/docs/ref-cicero-testing.md
+++ b/docs/ref-cicero-testing.md
@@ -307,7 +307,8 @@ Feature: IP Payment Contract
 
 If the template execution emits obligations, those can also be specified in the scenario as one of the **Then** steps.
 
-For instance, the following shows a scenario for the [Rental Deposit](https://templates.accordproject.org/ip-payment@0.10.1.html) template, which describes the expected list of obligations that should be emitted for a given request:
+For instance, the following shows a scenario for the [Rental Deposit](https://templates.accordproject.org/rental-deposit@0.10.1.html) template, which describes the expected list of obligations that should be emitted for a given request:
+
 ```gherkin
 Feature: Rental Deposit
   This describe the expected behavior for the Accord Project's rental deposit contract

--- a/docs/started-installation.md
+++ b/docs/started-installation.md
@@ -9,9 +9,9 @@ To experiment with Accord Project, you can install the Cicero command-line. This
 
 You must first obtain and configure the following dependency:
 
-* [Node.js (LTS)](http://nodejs.org): We use Node.js to run cicero, generate the documentation, run a development web server, testing, and produce distributable files. Depending on your system, you can install Node either from source or as a pre-packaged bundle.
+- [Node.js (LTS)](https://nodejs.org): We use Node.js to run cicero, generate the documentation, run a development web server, testing, and produce distributable files. Depending on your system, you can install Node either from source or as a pre-packaged bundle.
 
->  We recommend using [nvm](https://github.com/creationix/nvm) (or [nvm-windows](https://github.com/coreybutler/nvm-windows)) to manage and install Node.js, which makes it easy to change the version of Node.js per project.
+> We recommend using [nvm](https://github.com/nvm-sh/nvm) (or [nvm-windows](https://github.com/coreybutler/nvm-windows)) to manage and install Node.js, which makes it easy to change the version of Node.js per project.
 
 ## Installing Cicero
 
@@ -36,9 +36,9 @@ cicero --version
 To get command line help:
 ```bash
 cicero --help
-cicero parse --help     // To parse a sample clause/contract
-cicero draft --help     // To draft a sample clause/contract
-cicero trigger --help   // To send a request to a clause/contract
+cicero parse --help     # To parse a sample clause/contract
+cicero draft --help     # To draft a sample clause/contract
+cicero trigger --help   # To send a request to a clause/contract
 ```
 
 ## Optional Packages


### PR DESCRIPTION
# Closes  #N/A #

### Changes
- Fixed incorrect link for **Rental Deposit** template in [docs/ref-cicero-testing.md](cci:7://file:///c:/Users/Lenovo/techdocs/docs/ref-cicero-testing.md:0:0-0:0) (was incorrectly pointing to the IP Payment template).
- Updated outdated `http://nodejs.org` URL to secure `https://nodejs.org` in [docs/started-installation.md](cci:7://file:///c:/Users/Lenovo/techdocs/docs/started-installation.md:0:0-0:0).
- Updated deprecated `nvm` repository URL from `creationix/nvm` to the modern `nvm-sh/nvm` in [docs/started-installation.md](cci:7://file:///c:/Users/Lenovo/techdocs/docs/started-installation.md:0:0-0:0).
- Fixed Bash syntax error in [docs/started-installation.md](cci:7://file:///c:/Users/Lenovo/techdocs/docs/started-installation.md:0:0-0:0) code blocks (replaced Javascript-style `//` comments with Bash-style `#` comments).

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Documentation only changes.
- No functional code changes.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
N/A (Text-based documentation fixes)

### Related Issues
- N/A

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests (N/A for docs)
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `main` (or `master`) from `fix/docs-broken-links`
- [ ] Manual accessibility test performed