### PR TITLE
docs: fix broken Accord Project VS Code extension links

### DIFF
--- a/docs/started-resources.md
+++ b/docs/started-resources.md
@@ -24,7 +24,7 @@ Accord Project is also developing tools to help with authoring, testing and runn
 ### Editors
 
 - [Template Studio](https://studio.accordproject.org/): a Web-based editor for Accord Project templates
-- [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
+- [VSCode Extension][VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension): an Accord Project extension (Concerto) to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
 - [Emacs Mode](https://github.com/accordproject/ergo/tree/master/ergo.emacs): Emacs Major mode for Ergo (alpha)
 - [VIM Plugin](https://github.com/accordproject/ergo/tree/master/ergo.vim): VIM plugin for Ergo (alpha)
 

--- a/docs/tutorial-create.md
+++ b/docs/tutorial-create.md
@@ -56,7 +56,7 @@ bash-3.2$
 ```
 
 :::tip
-You may find it easier to edit the grammar, model and logic for your template in [VSCode](https://code.visualstudio.com/), installing the [Accord Project extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension). The extension gives you syntax highlighting and parser errors within VS Code.
+You may find it easier to edit the grammar, model and logic for your template in [VSCode Extension][VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension): an Accord Project extension (Concerto) to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
 
 For more information on how to use VS Code with the Accord Project extension, please consult the [Using the VS Code extension](tutorial-vscode) tutorial.
 :::

--- a/docs/tutorial-vscode.md
+++ b/docs/tutorial-vscode.md
@@ -14,7 +14,7 @@ To follow this tutorial on how to use the Cicero VS Code extension, we recommend
 1. [Yeoman](https://yeoman.io)
 1. [Accord Project Yeoman Generator](https://github.com/accordproject/cicero/tree/master/packages/generator-cicero-template)
 1. [Camel Tooling Yeoman VS Code extension](https://marketplace.visualstudio.com/items?itemName=camel-tooling.yo)
-1. [Accord Project VS Code extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension)
+1. [Accord Project VS Code extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension)
 
 ## Video Tutorial
 


### PR DESCRIPTION
I noticed that the links to the VS Code extension were pointing to the deprecated vscode-extension (returning a 404 error).

I have updated the links to the current Accord Project Extension in the following files:

started-resources.md

tutorial-vscode.md

tutorial-create.md