### PR TITLE
fixed issue 472 bug

### DIFF
--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -2408,6 +2408,20 @@ input::placeholder {
 .nav-footer .social {
   padding: 5px 0;
 }
+/* Ensure social icons in the footer follow the theme color and hover to white.
+   Use currentColor so SVG paths inherit the anchor color; apply !important to
+   override inline fills in vendor-provided SVGs (e.g., GitHub/Discord svgs). */
+.nav-footer .social a {
+  color: #19c6c6;
+  transition: color 150ms ease-in-out;
+}
+.nav-footer .social a svg,
+.nav-footer .social a svg path {
+  fill: currentColor !important;
+}
+.nav-footer .social a:hover {
+  color: #ffffff;
+}
 /* End of Footer */
 
 .tabs {


### PR DESCRIPTION
Title: Fix footer social icons — Discord uses theme color and white on hover

Closes #472

Summary

Make footer social icons (Discord) follow the site's mint theme color by default and switch to white on hover for consistent styling across icons.
Changes
Updated website/static/css/main.css
Added rules: .nav-footer .social a { color: #19c6c6 }, [svg, svg path { fill: currentColor !important }](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and .nav-footer .social a:hover { color: #ffffff }.
Verified markup in website/core/Footer.js; no structural changes required.
Flags
Uses !important to override inline fill attributes in vendor-provided SVGs; reviewers should confirm this is acceptable.
If a third-party SVG still renders white, the recommended alternative is editing that SVG in [website/static/img/](vscode-file://vscode-app/c:/Users/DELL/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to remove or change inline fill attributes for a robust fix.
Screenshots or Video
N/A — visual change in footer icon color/hover behavior.
Related Issues
Issue #472
