### PR TITLE
added fallbacks for issues

### DIFF
--- a/docs/accordproject.md
+++ b/docs/accordproject.md
@@ -39,6 +39,8 @@ If your organization wants to become a member of the Accord Project, please [joi
 The Accord Project provides a universal format for smart legal contracts, and this format is embodied in a variety of open source projects that comprise the Accord Project technology stack. The Accord Project is an open source project and welcomes contributions from anyone.
 
 The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
+  
+	_Note: if the Marketplace page shows a 404 on first load, click “Go back home” on that page or search for “Accord Project” in the VS Code Marketplace._
 
 There is a welcoming community on Discord that is eager to help. [Join our Community](https://discord.com/invite/Zm99SKhhtA)
 

--- a/docs/started-resources.md
+++ b/docs/started-resources.md
@@ -25,6 +25,8 @@ Accord Project is also developing tools to help with authoring, testing and runn
 
 - [Template Studio](https://studio.accordproject.org/): a Web-based editor for Accord Project templates
 - [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
+  
+	_Note: if the Marketplace page shows a 404 on first load, click “Go back home” on that page or search for “Accord Project” in the VS Code Marketplace. This is a known intermittent routing/redirect issue with the Marketplace._
 - [Emacs Mode](https://github.com/accordproject/ergo/tree/master/ergo.emacs): Emacs Major mode for Ergo (alpha)
 - [VIM Plugin](https://github.com/accordproject/ergo/tree/master/ergo.vim): VIM plugin for Ergo (alpha)
 

--- a/docs/tutorial-vscode.md
+++ b/docs/tutorial-vscode.md
@@ -15,6 +15,8 @@ To follow this tutorial on how to use the Cicero VS Code extension, we recommend
 1. [Accord Project Yeoman Generator](https://github.com/accordproject/cicero/tree/master/packages/generator-cicero-template)
 1. [Camel Tooling Yeoman VS Code extension](https://marketplace.visualstudio.com/items?itemName=camel-tooling.yo)
 1. [Accord Project VS Code extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension)
+    
+	_Note: if the Marketplace page shows a 404 on first load, click “Go back home” on that page or search for “Accord Project” in the VS Code Marketplace._
 
 ## Video Tutorial
 

--- a/website/versioned_docs/version-0.21/tutorial-vscode.md
+++ b/website/versioned_docs/version-0.21/tutorial-vscode.md
@@ -16,6 +16,8 @@ To follow this tutorial on how to use the Cicero VS Code extension, we recommend
 1. [Accord Project Yeoman Generator](https://github.com/accordproject/cicero/tree/master/packages/generator-cicero-template)
 1. [Camel Tooling Yeoman VS Code extension](https://marketplace.visualstudio.com/items?itemName=camel-tooling.yo)
 1. [Accord Project VS Code extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension)
+    
+	_Note: if the Marketplace page shows a 404 on first load, click “Go back home” on that page or search for “Accord Project” in the VS Code Marketplace._
 
 ## Video Tutorial
 

--- a/website/versioned_docs/version-0.30.1/accordproject.md
+++ b/website/versioned_docs/version-0.30.1/accordproject.md
@@ -41,6 +41,8 @@ The Accord Project provides a universal format for smart legal contracts, and th
 
 The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
 
+_Note: if the Marketplace page shows a 404 on first load, click “Go back home” on that page or search for “Accord Project” in the VS Code Marketplace._
+
 There is a welcoming community on Discord that is eager to help. [Join our Community](https://discord.com/invite/Zm99SKhhtA)
 
 

--- a/website/versioned_docs/version-0.30.1/started-resources.md
+++ b/website/versioned_docs/version-0.30.1/started-resources.md
@@ -26,6 +26,8 @@ Accord Project is also developing tools to help with authoring, testing and runn
 
 - [Template Studio](https://studio.accordproject.org/): a Web-based editor for Accord Project templates
 - [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
+  
+	_Note: if the Marketplace page shows a 404 on first load, click “Go back home” on that page or search for “Accord Project” in the VS Code Marketplace. This is a known intermittent routing/redirect issue with the Marketplace._
 - [Emacs Mode](https://github.com/accordproject/ergo/tree/master/ergo.emacs): Emacs Major mode for Ergo (alpha)
 - [VIM Plugin](https://github.com/accordproject/ergo/tree/master/ergo.vim): VIM plugin for Ergo (alpha)
 


### PR DESCRIPTION
Title: Add fallback guidance for VS Code Marketplace links

Summary: Added short fallback notes in the docs to help users who encounter an intermittent 404 when opening the Accord Project VS Code extension in the Visual Studio Marketplace. This is a documentation mitigation only (not a Marketplace or server-side fix).

Changes:

Files updated: docs/started-resources.md, website/versioned_docs/version-0.30.1/started-resources.md, docs/tutorial-vscode.md, website/versioned_docs/version-0.21/tutorial-vscode.md, docs/accordproject.md, website/versioned_docs/version-0.30.1/accordproject.md
What changed: each file now contains a one-line note advising: if the Marketplace page shows a 404 on first load, click “Go back home” on that page or search for “Accord Project” in the VS Code Marketplace.
Flags:

This is a user-facing workaround only; it does not fix the underlying Marketplace routing/redirect behavior.
Recommend the maintainers ask repository owners or the Marketplace team to verify the extension URL and server-side redirects, and consider automated link checks in CI.