### PR TITLE
fix(footer): make Linux Foundation logo hover consistent with footer theme

### DIFF
--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -2408,6 +2408,17 @@ input::placeholder {
 .nav-footer .social {
   padding: 5px 0;
 }
+
+/* Fix: Linux Foundation logo hover consistency */
+.nav-footer .linux-foundation-logo a {
+  opacity: 0.6;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.nav-footer .linux-foundation-logo a:hover {
+  opacity: 1;
+}
+
 /* End of Footer */
 
 .tabs {


### PR DESCRIPTION
## Description
Fixes the footer styling inconsistency where the Linux Foundation logo link showed default browser styling and did not match the hover interaction of other footer elements.

## Changes
- Added hover opacity effect for the Linux Foundation logo
- Ensured it follows the same visual behavior as other footer logos

Closes #471