### PR TITLE
fix(docs): update outdated VS Code extension marketplace links

### DIFF
--- a/website/versioned_docs/version-0.20/model-concerto.md
+++ b/website/versioned_docs/version-0.20/model-concerto.md
@@ -8,7 +8,7 @@ original_id: model-concerto
 
 The Concerto Modeling Language (CML) allows you to:
 - Define an object-oriented model using a domain-specific language that is much easier to read and write than JSON/XML Schema, XMI or equivalents.
-- Optionally edit your models using a powerful [VS Code add-on](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension) with syntax highlighting and validation
+- Optionally edit your models using a powerful [VS Code add-on](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension) with syntax highlighting and validation
 - Create runtime instances of your model
 - Serialize your instances to JSON
 - Deserialize (and optionally validate) instances from JSON

--- a/website/versioned_docs/version-0.20/started-resources.md
+++ b/website/versioned_docs/version-0.20/started-resources.md
@@ -25,7 +25,7 @@ Accord Project is also developing tools to help with authoring, testing and runn
 ### Editors
 
 - [Template Studio](https://studio.accordproject.org/): a Web-based editor for Accord Project templates
-- [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
+- [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
 - [Emacs Mode](https://github.com/accordproject/ergo/tree/master/ergo.emacs): Emacs Major mode for Ergo (alpha)
 - [VIM Plugin](https://github.com/accordproject/ergo/tree/master/ergo.vim): VIM plugin for Ergo (alpha)
 

--- a/website/versioned_docs/version-0.20/tutorial-create.md
+++ b/website/versioned_docs/version-0.20/tutorial-create.md
@@ -54,7 +54,7 @@ bash-3.2$ yo @accordproject/cicero-template
 ```
 
 :::tip
-You may find it easier to edit the grammar, model and logic for your template in [VSCode](https://code.visualstudio.com/), installing the [Accord Project extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension). The extension gives you syntax highlighting and parser errors within VS Code.
+You may find it easier to edit the grammar, model and logic for your template in [VSCode](https://code.visualstudio.com/), installing the [Accord Project extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension). The extension gives you syntax highlighting and parser errors within VS Code.
 :::
 
 ## Edit your template

--- a/website/versioned_docs/version-0.21/accordproject.md
+++ b/website/versioned_docs/version-0.21/accordproject.md
@@ -39,7 +39,7 @@ If your organization wants to become a member of the Accord Project, please [joi
 
 The Accord Project provides a universal format for smart legal contracts, and this format is embodied in a variety of open source projects that comprise the Accord Project technology stack. The Accord Project is an open source project and welcomes contributions from anyone.
 
-The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
+The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
 
 There is a welcoming community on Discord that is eager to help. [Join our Community](https://discord.com/invite/Zm99SKhhtA)
 

--- a/website/versioned_docs/version-0.21/model-concerto.md
+++ b/website/versioned_docs/version-0.21/model-concerto.md
@@ -8,7 +8,7 @@ original_id: model-concerto
 
 The Concerto Modeling Language (CML) allows you to:
 - Define an object-oriented model using a domain-specific language that is much easier to read and write than JSON/XML Schema, XMI or equivalents.
-- Optionally edit your models using a powerful [VS Code add-on](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension) with syntax highlighting and validation
+- Optionally edit your models using a powerful [VS Code add-on](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension) with syntax highlighting and validation
 - Create runtime instances of your model
 - Serialize your instances to JSON
 - Deserialize (and optionally validate) instances from JSON

--- a/website/versioned_docs/version-0.21/started-resources.md
+++ b/website/versioned_docs/version-0.21/started-resources.md
@@ -25,7 +25,7 @@ Accord Project is also developing tools to help with authoring, testing and runn
 ### Editors
 
 - [Template Studio](https://studio.accordproject.org/): a Web-based editor for Accord Project templates
-- [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
+- [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
 - [Emacs Mode](https://github.com/accordproject/ergo/tree/master/ergo.emacs): Emacs Major mode for Ergo (alpha)
 - [VIM Plugin](https://github.com/accordproject/ergo/tree/master/ergo.vim): VIM plugin for Ergo (alpha)
 

--- a/website/versioned_docs/version-0.21/tutorial-create.md
+++ b/website/versioned_docs/version-0.21/tutorial-create.md
@@ -57,7 +57,7 @@ bash-3.2$
 ```
 
 :::tip
-You may find it easier to edit the grammar, model and logic for your template in [VSCode](https://code.visualstudio.com/), installing the [Accord Project extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension). The extension gives you syntax highlighting and parser errors within VS Code.
+You may find it easier to edit the grammar, model and logic for your template in [VSCode](https://code.visualstudio.com/), installing the [Accord Project extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension). The extension gives you syntax highlighting and parser errors within VS Code.
 
 For more information on how to use VS Code with the Accord Project extension, please consult the [Using the VS Code extension](tutorial-vscode) tutorial.
 :::

--- a/website/versioned_docs/version-0.21/tutorial-vscode.md
+++ b/website/versioned_docs/version-0.21/tutorial-vscode.md
@@ -15,7 +15,7 @@ To follow this tutorial on how to use the Cicero VS Code extension, we recommend
 1. [Yeoman](https://yeoman.io)
 1. [Accord Project Yeoman Generator](https://github.com/accordproject/cicero/tree/master/packages/generator-cicero-template)
 1. [Camel Tooling Yeoman VS Code extension](https://marketplace.visualstudio.com/items?itemName=camel-tooling.yo)
-1. [Accord Project VS Code extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension)
+1. [Accord Project VS Code extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension)
 
 ## Video Tutorial
 

--- a/website/versioned_docs/version-0.22/tutorial-create.md
+++ b/website/versioned_docs/version-0.22/tutorial-create.md
@@ -57,7 +57,7 @@ bash-3.2$
 ```
 
 :::tip
-You may find it easier to edit the grammar, model and logic for your template in [VSCode](https://code.visualstudio.com/), installing the [Accord Project extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension). The extension gives you syntax highlighting and parser errors within VS Code.
+You may find it easier to edit the grammar, model and logic for your template in [VSCode](https://code.visualstudio.com/), installing the [Accord Project extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension). The extension gives you syntax highlighting and parser errors within VS Code.
 
 For more information on how to use VS Code with the Accord Project extension, please consult the [Using the VS Code extension](tutorial-vscode) tutorial.
 :::

--- a/website/versioned_docs/version-0.23.0/accordproject.md
+++ b/website/versioned_docs/version-0.23.0/accordproject.md
@@ -39,7 +39,7 @@ If your organization wants to become a member of the Accord Project, please [joi
 
 The Accord Project provides a universal format for smart legal contracts, and this format is embodied in a variety of open source projects that comprise the Accord Project technology stack. The Accord Project is an open source project and welcomes contributions from anyone.
 
-The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
+The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
 
 There is a welcoming community on Discord that is eager to help. [Join our Community](https://discord.com/invite/Zm99SKhhtA)
 

--- a/website/versioned_docs/version-0.30.1/accordproject.md
+++ b/website/versioned_docs/version-0.30.1/accordproject.md
@@ -39,7 +39,7 @@ If your organization wants to become a member of the Accord Project, please [joi
 
 The Accord Project provides a universal format for smart legal contracts, and this format is embodied in a variety of open source projects that comprise the Accord Project technology stack. The Accord Project is an open source project and welcomes contributions from anyone.
 
-The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
+The Accord Project is developing tools including a [Visual Studio Code plugin](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension), [React based web components](https://github.com/accordproject/web-components) and a command line interface for working with Accord Project Contracts. You can integrate contracts into existing applications, create new applications or simply assist lawyers with developing applications with the Ergo language. 
 
 There is a welcoming community on Discord that is eager to help. [Join our Community](https://discord.com/invite/Zm99SKhhtA)
 

--- a/website/versioned_docs/version-0.30.1/started-resources.md
+++ b/website/versioned_docs/version-0.30.1/started-resources.md
@@ -25,7 +25,7 @@ Accord Project is also developing tools to help with authoring, testing and runn
 ### Editors
 
 - [Template Studio](https://studio.accordproject.org/): a Web-based editor for Accord Project templates
-- [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.cicero-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
+- [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=accordproject.concerto-vscode-extension): an Accord Project extension to the popular [Visual Studio Code](https://visualstudio.microsoft.com/) Editor
 - [Emacs Mode](https://github.com/accordproject/ergo/tree/master/ergo.emacs): Emacs Major mode for Ergo (alpha)
 - [VIM Plugin](https://github.com/accordproject/ergo/tree/master/ergo.vim): VIM plugin for Ergo (alpha)
 


### PR DESCRIPTION
Closes #455
Closes #455

## Description
This PR fixes the broken VS Code extension link that was redirecting users to a 404 page on the Visual Studio Marketplace.  
All outdated occurrences of the old marketplace URL have been replaced with the correct working link so users are now redirected properly.

## Changes
- Updated the VS Code extension marketplace URL across the documentation where the old link was used
- Verified locally that the link opens the correct extension page without errors

## Flags
- No functional code changes
- Documentation-only update

## Screenshots or Video
N/A – Link update verified by testing locally with `npm start` and opening the updated pages in the browser.

## Related Issues
- Issue #455

## Author Checklist
- [ ] Ensure you provide a DCO sign-off for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:fix-vscode-extension-link`
- [ ] Manual accessibility test performed