### PR TITLE
fix: homepage layout, broken links, and Ergo-to-TypeScript migration

### DIFF
--- a/docs/accordproject-template.md
+++ b/docs/accordproject-template.md
@@ -130,7 +130,7 @@ The combination of text and model already makes templates _machine-readable_, wh
 
 ### During Drafting
 
-In the [Overview](accordproject.md) Section, we already saw how logic can be embedded in the text of the template itself to automatically calculate a monthly payment for a [fixed rate loan]():
+In the [Overview](accordproject.md) Section, we already saw how logic can be embedded in the text of the template itself to automatically calculate a monthly payment for a [fixed rate loan](https://playground.accordproject.org):
 
 ```tem
 ## Fixed rate loan

--- a/docs/started-hello.md
+++ b/docs/started-hello.md
@@ -11,13 +11,13 @@ You can download a single clause or contract template from the [Accord Project T
 
 If you click on the Template Library link, you should see a Web Page which looks as follows:
 
-![Basic-Use-1](/docs/assets/basic/use1.png)
+![Basic-Use-1](./assets/basic/use1.png)
 
 Scrolling down that page, you can see the index for the open-source templates along with their version, and whether they are a Clause or Contract template.
 
 Click on the link to the `helloworld` template. You should be taken to a page which looks as follows:
 
-![Basic-Use-2](/docs/assets/basic/use2.png)
+![Basic-Use-2](./assets/basic/use2.png)
 
 Then click on the `Download Archive` button under the description for the template (highlighted in the red box in the figure). This should download the latest template archive for the `helloworld` template.
 
@@ -208,7 +208,7 @@ Then run `cicero trigger --template helloworld@0.14.0.cta --sample sample.md --r
 
 Feel free to try the same commands to parse and execute other templates from the Accord Project Library. Note that for each template, you can find samples for the text, for the request and for the state on the corresponding Web page. For instance, a sample for the [Late Delivery And Penalty](https://templates.accordproject.org/latedeliveryandpenalty@0.15.0.html) clause is in the red box in the following image:
 
-![Basic-Use-3](/docs/assets/basic/use3.png)
+![Basic-Use-3](./assets/basic/use3.png)
 
 ### More About Cicero
 

--- a/docs/tutorial-create.md
+++ b/docs/tutorial-create.md
@@ -45,7 +45,7 @@ bash-3.2$ yo @accordproject/cicero-template
    create mylease/logo.png
    create mylease/package.json
    create mylease/request.json
-   create mylease/logic/logic.ergo
+   create mylease/logic/logic.ts
    create mylease/model/model.cto
    create mylease/test/logic_default.feature
    create mylease/text/grammar.tem.md
@@ -109,13 +109,14 @@ bash-3.2$ npm install
 bash-3.2$ npm run test 
 
 > mylease@0.0.0 test /Users/jeromesimeon/tmp/mylease
-> cucumber-js test -r .cucumber.js
+> vitest run
 
-....
+ ✓ logic.test.ts (1 test)
 
-1 scenario (1 passed)
-3 steps (3 passed)
-0m01.257s
+ Test Files 1 passed (1)
+      Tests 1 passed (1)
+   Start at 12:01:05
+   Duration 1.25s
 bash-3.2$ 
 ```
 
@@ -162,10 +163,25 @@ caller.
 
 ### Edit the Template Logic
 
-Now edit the business logic of the template itself. This is expressed in the Ergo language, which is a strongly-typed function domain specific language for contract logic. Open the file `logic/logic.ergo`
-and edit the `helloworld` clause to perform the calculations your logic requires.
+Now edit the business logic of the template itself. Template logic is written in **TypeScript** using a class-based pattern. Open the file `logic/logic.ts` and edit the `trigger` method to perform the calculations your logic requires.
 
-Looking at the Ergo logic for other example templates will help you understand the syntax and capabilities of Ergo.
+For example, a basic TypeScript logic class looks like this:
+```typescript
+import { MyContract, MyRequest, MyResponse } from './model/model';
+import { TemplateLogic } from '@accordproject/cicero-core';
+
+class MyLogic extends TemplateLogic<MyContract> {
+  async trigger(data: MyContract, request: MyRequest): Promise<{ response: MyResponse }> {
+    const response: MyResponse = {
+      $class: 'org.acme.lease.MyResponse',
+      output: `Hello ${data.name} ${request.input}`,
+    };
+    return { response };
+  }
+}
+```
+
+Looking at the TypeScript logic for other example templates in the [cicero-template-library](https://github.com/accordproject/cicero-template-library) will help you understand the syntax and capabilities.
 
 ## Publishing your template
 

--- a/docs/tutorial-library.md
+++ b/docs/tutorial-library.md
@@ -29,7 +29,7 @@ git clone https://github.com/accordproject/cicero-template-library
 
 Alternatively, you can download the library directly by visiting the [GitHub Repository for the Template Library](https://github.com/accordproject/cicero-template-library) and use the "Download" button as shown on this snapshot:
 
-![Basic-Library-1](/docs/assets/basic/library1.png)
+![Basic-Library-1](./assets/basic/library1.png)
 
 ### Install the Library
 
@@ -82,14 +82,13 @@ $ bash-3.2$ ls -laR
   ./sample.md
 
 ./logic:
-   logic.ergo
+   logic.ts
 
 ./model:
    model.cto
 
 ./test:
-  logic.feature
-  logic_default.feature
+  logic.test.ts
 
 ./request.json
 ./state.json

--- a/docs/tutorial-templates.md
+++ b/docs/tutorial-templates.md
@@ -26,10 +26,9 @@ Archive:  helloworld@0.14.0.cta
  extracting: model/@models.accordproject.org.accordproject.money@0.2.0.cto  
  extracting: model/@models.accordproject.org.accordproject.contract.cto  
  extracting: model/@models.accordproject.org.accordproject.runtime.cto  
- extracting: model/@org.accordproject.ergo.options.cto  
  extracting: model/model.cto         
    creating: logic/
- extracting: logic/logic.ergo        
+ extracting: logic/logic.ts        
 ```
 
 ## Template Components
@@ -54,7 +53,7 @@ model/
     and models for the State, Request, Response, and Obligations used during execution.
 
 logic/
-    A collection of Ergo files that implement the business logic for the template
+    A collection of TypeScript files that implement the business logic for the template
 
 test/
     A collection of unit tests for the template
@@ -98,7 +97,7 @@ The file in `model/model.cto` contains the data model for the template. This inc
 
 Here is the model for the `helloworld` template:
 
-```ergo
+```concerto
 namespace org.accordproject.helloworld
 
 import org.accordproject.contract.* from https://models.accordproject.org/accordproject/contract.cto
@@ -137,26 +136,24 @@ Types are always declared within a namespace (here `org.accordproject.helloworld
 
 ### Template Logic
 
-The file in `logic/logic.ergo` contains the executable logic. Each Ergo file is identified by a namespace, and contains declarations (e.g., constants, functions, contracts). Here is the Ergo logic for the `helloworld` template:
+The file in `logic/logic.ts` contains the executable TypeScript logic. Here is the TypeScript logic for the `helloworld` template:
 
-```ergo
-namespace org.accordproject.helloworld
+```typescript
+import { HelloWorldClause, MyRequest, MyResponse } from './model/model';
+import { TemplateLogic } from '@accordproject/cicero-core';
 
-contract HelloWorld over TemplateModel {
-  // Simple Clause
-  clause greet(request : MyRequest) : MyResponse {
-    return MyResponse{ output: "Hello " ++ contract.name ++ " " ++ request.input }
+class HelloWorld extends TemplateLogic<HelloWorldClause> {
+  async trigger(data: HelloWorldClause, request: MyRequest): Promise<{ response: MyResponse }> {
+    const response: MyResponse = {
+      $class: 'org.accordproject.helloworld.MyResponse',
+      output: `Hello ${data.name} ${request.input}`,
+    };
+    return { response };
   }
 }
 ```
 
-This declares a single `HelloWorld` contract in the `org.accordproject.helloworld` namespace, with one `greet` clause.
-
-It also declares that this contract `HelloWorld` is parameterized over the given `TemplateModel` found in the `models/model.cto` file.
-
-The `greet` clause takes a request of type `MyRequest` as input and returns a response of type `MyResponse`.
-
-The code for the `greet` clause returns a new `MyResponse` response with a single property `output` which is a string. That string is constructed using the string concatenation operator (`++`) in Ergo from the `name` in the contract (`contract.name`) and the input from the request (`request.input`).
+This declares a `HelloWorld` class extending `TemplateLogic`, typed with the `HelloWorldClause` model. The `trigger` method takes the clause data and a `MyRequest` as input and returns a `MyResponse` with an `output` string.
 
 ## Use the Template
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -161,7 +161,6 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.49.1.tgz",
       "integrity": "sha512-Nt9hri7nbOo0RipAsGjIssHkpLMHHN/P7QqENywAq5TLsoYDzUyJGny8FEiD/9KJUxtGH8blGpMedilI6kK3rA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.49.1",
         "@algolia/requester-browser-xhr": "5.49.1",
@@ -287,7 +286,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2090,7 +2088,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2113,7 +2110,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2223,7 +2219,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2645,7 +2640,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3626,7 +3620,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -4618,7 +4611,6 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -5082,7 +5074,6 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5445,7 +5436,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5787,7 +5777,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5855,7 +5844,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5901,7 +5889,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.49.1.tgz",
       "integrity": "sha512-X3Pp2aRQhg4xUC6PQtkubn5NpRKuUPQ9FPDQlx36SmpFwwH2N0/tw4c+NXV3nw3PsgeUs+BuWGP0gjz3TvENLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.15.1",
         "@algolia/client-abtesting": "5.49.1",
@@ -6381,7 +6368,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7347,7 +7333,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -8712,7 +8697,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13143,7 +13127,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13676,7 +13659,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14580,7 +14562,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15397,7 +15378,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15410,7 +15390,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -15467,7 +15446,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -15496,7 +15474,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -17261,8 +17238,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -17670,7 +17646,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17869,7 +17844,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
       "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -8,4 +8,205 @@
   --ifm-color-primary-lightest: #36e5e5;
   --ifm-navbar-background-color: #1b2540;
   --ifm-navbar-link-color: #ffffff;
+  --ifm-navbar-link-hover-color: #19C6C6;
+  --ifm-footer-background-color: #1b2540;
+  --ifm-footer-color: #ffffff;
+  --ifm-footer-link-color: #adb5bd;
+  --ifm-footer-link-hover-color: #19C6C6;
+}
+
+/* ===== HOMEPAGE HERO ===== */
+.heroCover {
+  background: linear-gradient(135deg, #1b2540 0%, #0d1526 100%);
+  color: #ffffff;
+}
+
+.homeContainer {
+  text-align: center;
+  padding: 60px 20px 20px;
+  color: #ffffff;
+}
+
+.homeContainer .projectTitle {
+  color: #ffffff;
+  font-size: 2.8rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+.homeContainer .projectTitle .lead {
+  color: #19C6C6;
+}
+
+/* CTA buttons on hero */
+.pluginWrapper.buttonWrapper {
+  display: inline-block;
+  margin: 0 8px;
+}
+
+.homeContainer .button,
+.heroCover .button {
+  border: 2px solid #ffffff;
+  color: #ffffff;
+  background: transparent;
+  border-radius: 4px;
+  padding: 10px 22px;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.3s, color 0.3s, border-color 0.3s;
+  text-decoration: none !important;
+  display: inline-block;
+}
+
+.homeContainer .button:hover,
+.heroCover .button:hover {
+  background: #19C6C6;
+  border-color: #19C6C6;
+  color: #1b2540;
+}
+
+/* ===== FEATURES SECTION ===== */
+#features {
+  background: #1b2540;
+  padding: 40px 0;
+}
+
+#features .blockContent h2 {
+  color: #19C6C6;
+  font-size: 1.1rem;
+}
+
+#features .blockContent h2 a {
+  color: #19C6C6;
+  text-decoration: none;
+}
+
+#features .blockContent h2 a:hover {
+  color: #ffffff;
+}
+
+#features .blockContent > div {
+  color: #adb5bd;
+  font-size: 0.95rem;
+}
+
+/* ===== CONTENT BLOCKS ===== */
+.darkBackground {
+  background-color: #f0f4f8;
+}
+
+.paddingBottom {
+  padding-bottom: 40px;
+}
+
+.paddingTop {
+  padding-top: 40px;
+}
+
+.blockElement {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+
+.blockElement.imageAlignRight {
+  flex-direction: row;
+}
+
+.blockElement.imageAlignLeft {
+  flex-direction: row-reverse;
+}
+
+.blockImage img {
+  max-width: 480px;
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+}
+
+.blockContent h2 {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+  color: #1b2540;
+}
+
+.darkBackground .blockContent h2 {
+  color: #1b2540;
+}
+
+.typeset {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #444;
+}
+
+.darkBackground .typeset {
+  color: #333;
+}
+
+/* ===== SHOWCASE SECTION ===== */
+.productShowcaseSection {
+  text-align: center;
+  padding: 40px 20px;
+  background: #f8f9fa;
+}
+
+.productShowcaseSection h2 {
+  font-size: 1.8rem;
+  margin-bottom: 8px;
+}
+
+.productShowcaseSection .logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
+  margin: 24px 0;
+}
+
+.productShowcaseSection .logos img {
+  height: 50px;
+  object-fit: contain;
+  filter: grayscale(0.3);
+  transition: filter 0.3s;
+}
+
+.productShowcaseSection .logos img:hover {
+  filter: none;
+}
+
+.button-filled {
+  background: #1b2540;
+  color: #fff !important;
+  border: none;
+  border-radius: 4px;
+  padding: 10px 24px;
+  font-weight: 600;
+  display: inline-block;
+  transition: background 0.3s;
+  text-decoration: none !important;
+}
+
+.button-filled:hover {
+  background: #19C6C6;
+  color: #1b2540 !important;
+}
+
+/* ===== RESPONSIVE ===== */
+@media (max-width: 768px) {
+  .blockElement.imageAlignRight,
+  .blockElement.imageAlignLeft {
+    flex-direction: column;
+  }
+
+  .blockImage img {
+    max-width: 100%;
+  }
+
+  .homeContainer .projectTitle {
+    font-size: 2rem;
+  }
 }

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -28,7 +28,7 @@ const users = [
   },
 ];
 
-function Button({href, target, children}) {
+function Button({ href, target, children }) {
   return (
     <div className="pluginWrapper buttonWrapper">
       <a className="button" href={href} target={target || '_self'}>
@@ -70,12 +70,12 @@ function Features() {
       content: 'Create templates for human-readable and machine-executable contracts using Open Source <a href="/docs/started-installation">Cicero</a>.',
     },
     {
-      title: <a href="/docs/logic-ergo"><img src="/img/ergo-logo.svg" alt="Ergo" /></a>,
-      content: 'Write executable business logic for legal contracts using the <a href="/docs/logic-ergo">Ergo</a> domain-specific language.',
+      title: <a href="/docs/logic-typescript"><strong>Template Logic</strong></a>,
+      content: 'Write executable business logic for legal contracts using <a href="/docs/logic-typescript">TypeScript</a>, with types generated from your Concerto model.',
     },
     {
-      title: <a href="/docs/model-concerto">Concerto</a>,
-      content: 'Model the data for your contracts in a platform neutral format with the <a href="/docs/model-concerto">Concerto</a> schema language.',
+      title: <a href="https://concerto.accordproject.org/docs/intro">Concerto</a>,
+      content: 'Model the data for your contracts in a platform neutral format with the <a href="https://concerto.accordproject.org/docs/intro">Concerto</a> schema language.',
     },
     {
       title: <a href="https://templates.accordproject.org/">Template Library</a>,
@@ -95,7 +95,7 @@ function Features() {
             <div key={i} className="blockElement alignCenter threeByGridBlock">
               <div className="blockContent">
                 <h2>{item.title}</h2>
-                <div dangerouslySetInnerHTML={{__html: item.content}} />
+                <div dangerouslySetInnerHTML={{ __html: item.content }} />
               </div>
             </div>
           ))}
@@ -105,7 +105,7 @@ function Features() {
   );
 }
 
-function ContentBlock({id, background, imageAlign, title, content, image, imageAlt}) {
+function ContentBlock({ id, background, imageAlign, title, content, image, imageAlt }) {
   const bgClass = background === 'dark' ? 'darkBackground' : '';
   const hasImage = !!image;
   const imageAlignClass = imageAlign === 'right' ? 'imageAlignRight' : 'imageAlignLeft';
@@ -124,8 +124,8 @@ function ContentBlock({id, background, imageAlign, title, content, image, imageA
               </div>
             )}
             <div className="blockContent">
-              <h2 dangerouslySetInnerHTML={{__html: title}} />
-              <div dangerouslySetInnerHTML={{__html: content}} />
+              <h2 dangerouslySetInnerHTML={{ __html: title }} />
+              <div dangerouslySetInnerHTML={{ __html: content }} />
             </div>
             {hasImage && imageAlign !== 'left' && (
               <div className="blockImage">
@@ -197,7 +197,7 @@ export default function Home() {
           <ContentBlock
             id="model"
             title="Model"
-            content='<div class="typeset">Concerto lets you model the data used in your templates in a flexible and expressive way. Models can be written in a modular and portable way so they can be reused in a variety of contracts.</div>'
+            content='<div class="typeset">Concerto lets you model the data used in your templates in a flexible and expressive way. Models can be written in a modular and portable way so they can be reused in a variety of contracts. <a href="https://concerto.accordproject.org/docs/intro">Learn more about Concerto.</a></div>'
             image="/img/model-uml.png"
             imageAlt="A diagram with an example of a Concerto model"
             imageAlign="right"
@@ -206,9 +206,9 @@ export default function Home() {
             id="logic"
             background="dark"
             title="Logic"
-            content='<div class="typeset">Ergo is a <em>strongly-typed</em> domain specific language designed to capture computational aspects of legal contracts and clauses. Use Ergo to create <strong>safe</strong> smart legal contract logic.</div>'
-            image="/docs/assets/020/ergo.png"
-            imageAlt="Example of an Ergo file"
+            content='<div class="typeset">Template logic is written in <em>TypeScript</em> using a class-based pattern that integrates directly with the Concerto data model. Logic can be embedded inline in template text or defined in a separate TypeScript class that extends <code>TemplateLogic</code>.</div>'
+            image="/docs/assets/020/template_logic.png"
+            imageAlt="Example of TypeScript template logic code"
             imageAlign="left"
           />
           <ContentBlock


### PR DESCRIPTION
# Closes #506

### Changes
- Homepage Layout: Added full CSS styling to custom.css for hero gradient, buttons, and features section.
- Content Updates: Replaced Ergo with TypeScript / Template Logic card on the homepage.
- Logic Section: Updated Logic block with TypeScript description and new template_logic.png image.
- Broken Links: Fixed model-concerto link to point to external Concerto docs.
- Broken Images: Fixed 4 broken image paths in started-hello.md and tutorial-library.md using relative paths.
- Tutorial Migration: Updated tutorials (templates, library, and create) to use logic.ts and vitest instead of Ergo and cucumber.

### Flags
- Open against mr-remove-ergo branch for easier review as requested by the maintainer.
- References cicero-template-library PR #484.
