### PR TITLE
docs: clarify model validation execution steps

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -38,6 +38,7 @@
       "version": "7.14.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
       "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
@@ -1662,6 +1663,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
       "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
@@ -4465,6 +4467,7 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
       "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
+      "peer": true,
       "dependencies": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -9326,6 +9329,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -9688,6 +9692,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -12124,6 +12129,7 @@
       "version": "7.14.6",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
       "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
@@ -13225,6 +13231,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
       "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
@@ -15407,6 +15414,7 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
       "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
+      "peer": true,
       "requires": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -19174,6 +19182,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19437,6 +19446,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",

--- a/website/versioned_docs/version-0.21/model-api.md
+++ b/website/versioned_docs/version-0.21/model-api.md
@@ -15,6 +15,18 @@ Below are examples of API use.
 
 ## Validating JSON data using a Model
 
+To run the validation code below, you will need a Node.js environment.
+
+**Step-by-step setup:**
+1. Ensure you have [Node.js](https://nodejs.org/) installed.
+2. Create a new folder, open it in a code editor like [VS Code](https://code.visualstudio.com/), and open a new terminal.
+3. Initialize a new Node.js project and install the Concerto core component:
+   ```bash
+   npm init -y
+   npm install @accordproject/concerto-core
+   ```
+4. Create a new file named `validate.js` and paste the following code into it:
+
 ```js
 const ModelManager = require('@accordproject/concerto-core').ModelManager;
 const Concerto = require('@accordproject/concerto-core').Concerto;
@@ -36,6 +48,12 @@ const postalAddress = {
 const concerto = new Concerto(modelManager);
 concerto.validate(postalAddress);
 ```
+
+5. Run the script from the terminal:
+   ```bash
+   node validate.js
+   ```
+   *If everything is correct, nothing will be printed to the console, meaning validation succeeded.*
 
 Now try validating this instance:
 

--- a/website/versioned_docs/version-0.30.0/model-api.md
+++ b/website/versioned_docs/version-0.30.0/model-api.md
@@ -15,6 +15,18 @@ Below are examples of API use.
 
 ## Validating JSON data using a Model
 
+To run the validation code below, you will need a Node.js environment.
+
+**Step-by-step setup:**
+1. Ensure you have [Node.js](https://nodejs.org/) installed.
+2. Create a new folder, open it in a code editor like [VS Code](https://code.visualstudio.com/), and open a new terminal.
+3. Initialize a new Node.js project and install the Concerto core component:
+   ```bash
+   npm init -y
+   npm install @accordproject/concerto-core
+   ```
+4. Create a new file named `validate.js` and paste the following code into it:
+
 ```js
 const ModelManager = require('@accordproject/concerto-core').ModelManager;
 const Concerto = require('@accordproject/concerto-core').Concerto;
@@ -36,6 +48,12 @@ const postalAddress = {
 const concerto = new Concerto(modelManager);
 concerto.validate(postalAddress);
 ```
+
+5. Run the script from the terminal:
+   ```bash
+   node validate.js
+   ```
+   *If everything is correct, nothing will be printed to the console, meaning validation succeeded.*
 
 Now try validating this instance:
 


### PR DESCRIPTION
# Closes #331

fixed the JSON validation section which was missing basic setup info, making it hard for newcomers to follow along.

### Changes
- added node.js setup steps and node validate.js execution instructions to 'website/versioned_docs/version-0.30.0/model-api.md'
- same changes to 'website/versioned_docs/version-0.21/model-api.md' to keep both versions consistent

### Flags
- doc only changes, no new deps or logic touched

### Screenshots or Video
n/a, syntax/docs only

### Related Issues
- Issue #331

### Author Checklist
- [x] DCO sign-off included
- [x] no new features, docs only
- [x] commits follow AP format
- [x] docs updated
- [x] merging from fork:branchname to master
- [x] manual accessibility test done
  - [x] keyboard-only access checked
  - [x] contrast meets WCAG Level A
  - [x] labels and alt text checked