### PR TITLE
fix(ci): use native AWS CLI for CloudFront invalidation

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -63,8 +63,9 @@ jobs:
 
       - name: Invalidate Cloudfront
         if: github.ref == 'refs/heads/main'
-        uses: chetan/invalidate-cloudfront-action@master
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"
         env:
-          DISTRIBUTION: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
-          PATHS: '/*'
           AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
## Summary
Fix CloudFront cache invalidation failure with OIDC authentication.

## Problem
The `chetan/invalidate-cloudfront-action@master` runs in a Docker container and doesn't inherit OIDC credentials set by `aws-actions/configure-aws-credentials`. This causes:
```
An error occurred (InvalidClientTokenId) when calling the CreateInvalidation operation: The security token included in the request is invalid.
```

## Solution
Replace the Docker-based action with native AWS CLI (`aws cloudfront create-invalidation`) which correctly inherits the OIDC session credentials.

## Author Checklist
- [x] DCO sign-off provided
- [x] Follows Accord Project commit format