### PR TITLE
fix(css): remove negative top offset on .anchor headings

### DIFF
--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -1721,12 +1721,6 @@ input::placeholder {
   color: #393939;
 }
 
-@media only screen and (max-width: 735px) {
-  .anchor {
-    top: -144px;
-  }
-}
-
 @media only screen and (min-width: 1024px) {
   .toc {
     padding: 40px 0;


### PR DESCRIPTION
## Summary

- Removes `top: -144px` from the `.anchor` mobile media query in `main.css`

Headings were visually overlapping the content above them because `.anchor` elements (applied to all H2/H3 headings by Docusaurus) were being pulled upward by negative `top` values — a legacy technique for offsetting anchors below a sticky navbar. Docusaurus now handles this correctly via `scroll-margin-top`, making these rules redundant.

The deployed site also has a desktop `top: -80px` on `.anchor` (not present in the repo) which will resolve on next deploy.

## Test plan

- [x] Verify headings on `/docs/started-installation/` and other doc pages sit correctly below their preceding content
- [x] Check anchor link behaviour (clicking TOC links) still scrolls to the correct position below the sticky navbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)