### PR TITLE
fix: upgrade Node.js to 22 in CI workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -19,16 +19,16 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
         # Ensure npm 11.5.1 or later for trusted publishing


### PR DESCRIPTION
## Summary

- Upgrades Node.js from 20 to 22 in the build workflow
- `npm@latest` (v12.x) requires Node `>=22`; the build was failing with `EBADENGINE` on Node 20

## Test plan

- [ ] Confirm CI build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)