### PR TITLE
fix: move preinstall lint checks to a lint script run after install

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -34,6 +34,9 @@ jobs:
         # Ensure npm 11.5.1 or later for trusted publishing
       - run: npm install -g npm@latest
 
+        # preinstall script requires these tools before npm install runs
+      - run: npm install -g lockfile-lint syncpack
+
       - name: NPM Install
         if: github.ref == 'refs/heads/main'
         working-directory: ./website

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -34,13 +34,15 @@ jobs:
         # Ensure npm 11.5.1 or later for trusted publishing
       - run: npm install -g npm@latest
 
-        # preinstall script requires these tools before npm install runs
-      - run: npm install -g lockfile-lint syncpack
-
       - name: NPM Install
         if: github.ref == 'refs/heads/main'
         working-directory: ./website
         run: npm install
+
+      - name: NPM Lint
+        if: github.ref == 'refs/heads/main'
+        working-directory: ./website
+        run: npm run lint
 
       - name: NPM Build
         if: github.ref == 'refs/heads/main'

--- a/website/package.json
+++ b/website/package.json
@@ -12,10 +12,10 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
+    "lint": "npm run lint:lockfile && npm run lint:deps",
     "lint:deps": "syncpack lint",
     "lint:deps:fix": "syncpack fix",
-    "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https",
-    "preinstall": "npm run lint:lockfile && npm run lint:deps"
+    "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --allowed-hosts npm --validate-https"
   },
   "description": "Technical Documentation for the Accord Project",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- `preinstall` was calling `lockfile-lint` and `syncpack` before they were installed — a chicken-and-egg problem
- Following the pattern in `concerto-codegen`: moves those checks into a `lint` script that runs after `npm install`
- Adds an explicit `NPM Lint` step to the CI workflow

## Test plan

- [ ] Confirm CI build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)