### PR TITLE
docs(ref-apap): add Deploy on Railway section

### DIFF
--- a/docs/ref-apap.md
+++ b/docs/ref-apap.md
@@ -254,6 +254,24 @@ npm start          # or: npm run dev  (hot-reload)
 npx drizzle-kit push   # first run only
 ```
 
+### Deploy on Railway
+
+Click the button below to provision the server and a managed Postgres instance in one click:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/QYiXk5?referralCode=Gx6QTA&utm_medium=integration&utm_source=template&utm_campaign=generic)
+
+Once deployed, your server is available at the Railway-assigned URL (e.g. `https://my-apap.up.railway.app`). No database setup required — Postgres is provisioned and linked automatically.
+
+:::note
+This deployment is a sample implementation and is not hardened for production use.
+:::
+
+To verify the deployment:
+
+```bash
+curl https://my-apap.up.railway.app/capabilities
+```
+
 ---
 
 ## MCP Support (experimental)


### PR DESCRIPTION
## Summary

- Adds a **Deploy on Railway** section to the APAP reference page (`docs/ref-apap.md`), mirroring the instructions in the [accordproject/apap README](https://github.com/accordproject/apap#deploy-on-railway)
- Includes the one-click Railway deploy button, a description of automatic Postgres provisioning, a production-hardening caution note, and a verify step
- Placed within the existing **Reference Implementation** section, after the local and Docker run instructions

## Test plan

- [ ] Confirm the Railway deploy button renders correctly in the docs site
- [ ] Confirm the `:::note` admonition renders correctly (Docusaurus)
- [ ] Check the Railway deploy URL is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)