### PR TITLE
fix(ref-apap): correct Railway deploy URL

### DIFF
--- a/docs/ref-apap.md
+++ b/docs/ref-apap.md
@@ -258,7 +258,7 @@ npx drizzle-kit push   # first run only
 
 Click the button below to provision the server and a managed Postgres instance in one click:
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/QYiXk5?referralCode=Gx6QTA&utm_medium=integration&utm_source=template&utm_campaign=generic)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/apap-sample?referralCode=Gx6QTA&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
 Once deployed, your server is available at the Railway-assigned URL (e.g. `https://my-apap.up.railway.app`). No database setup required — Postgres is provisioned and linked automatically.
 

--- a/docs/ref-apap.md
+++ b/docs/ref-apap.md
@@ -254,6 +254,24 @@ npm start          # or: npm run dev  (hot-reload)
 npx drizzle-kit push   # first run only
 ```
 
+### Deploy on Railway
+
+Click the button below to provision the server and a managed Postgres instance in one click:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/QYiXk5?referralCode=Gx6QTA&utm_medium=integration&utm_source=template&utm_campaign=generic)
+
+Once deployed, your server is available at the Railway-assigned URL (e.g. `https://my-apap.up.railway.app`). No database setup required — Postgres is provisioned and linked automatically.
+
+:::note
+This deployment is a sample implementation and is not hardened for production use.
+:::
+
+To verify the deployment:
+
+```bash
+curl https://my-apap.up.railway.app/capabilities
+```
+
 ---
 
 ## MCP Support (experimental)


### PR DESCRIPTION
## Summary

- Fixes the Railway one-click deploy link in the APAP reference page
- Updates the template slug from the old short ID (`QYiXk5`) to the correct named slug (`apap-sample`)

Correct URL: `https://railway.com/deploy/apap-sample?referralCode=Gx6QTA&utm_medium=integration&utm_source=template&utm_campaign=generic`

> Depends on #554 (adds the Railway section)

## Test plan

- [ ] Confirm the deploy button links to the correct Railway template

🤖 Generated with [Claude Code](https://claude.com/claude-code)